### PR TITLE
Improve README and Python Runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ Execute the following commands:
 
 ```sh
 $ cd opencl/samples
-$ ./ttl_sample_runner.py *.cl
+$ ./TTL_sample_runner.py *.cl
 $ cd ../c/samples
-$ ./ttl_sample_runner.py *.c
+$ ./TTL_sample_runner.py *.c
 ```
 
 #### Installation

--- a/README.md
+++ b/README.md
@@ -1,26 +1,33 @@
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
-<p align="center"><img width="30%" src="doc/tensor_tiling_library.png" /></p>
-
-# Tensor Tiling Library
+<h1 align="center">Tensor Tiling Library</h1>
+<p align="center">
+  <img width="30%" src="doc/tensor_tiling_library.png" />
+</p>
+<p align="center">
+  <a href="https://opensource.org/licenses/Apache-2.0">
+    <img src="https://img.shields.io/badge/license-Apache%20-blue.svg" alt="License">
+  </a>
+  <a href="https://github.com/KhronosGroup/OpenCL-TTL/issues">
+    <img src="https://img.shields.io/github/issues/KhronosGroup/OpenCL-TTL" alt="Issues">
+  </a>
+</p>
 
 Tensor & Tiling Library is an open-source library to enable the efficient tiling and compute with tensors.
 
 Please reach out to chris.gearing@mobileye.com or ayal.zaks@mobileye.com for more information.
 
-This document outlines the purpose of this sample implementation as well as provide build and execution instructions.
+This document outlines the purpose of this sample implementation and provides build and execution instructions.
 
-## CONTENTS: <!-- omit in toc -->
+## Contents <!-- omit in toc -->
 
 - [Tensor Tiling Library](#tensor-tiling-library)
   - [Purpose](#purpose)
-  - [Example Source](#example-source)
+  - [Example](#example)
   - [Building And Executing](#building-and-executing)
     - [CMake](#cmake)
-      - [Tested Supported systems:](#tested-supported-systems)
-      - [Pre-requisite:](#pre-requisite)
-      - [Building Samples:](#building-samples)
-      - [Install:](#install)
+      - [Tested Supported Systems](#tested-supported-systems)
+      - [Requirements](#requirements)
+      - [Building the Samples](#building-the-samples)
+      - [Installation](#installation)
   - [Included Unit Tests](#included-unit-tests)
   - [Bug Reporting](#bug-reporting)
 
@@ -30,18 +37,18 @@ The purpose of this software package is to provide a simple to use standardized 
 
 The library is intended to be general purpose and usable on all architectures.
 
-Currently the Tensor Tiling Library is:
+Currently the Tensor Tiling Library:
 
-* passing its own unit tests
+* passes its own unit tests
 * contains reference implementations
-* optimized
+* is optimized
 
-## Example Source
+## Example
 
 This is a double tiling example where the data is simultaneously moved from host<->device whilst the
 compute is occurring.
 
-```
+```c
 #include "TTL/TTL.h"
 
 __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int external_stride_in,
@@ -96,42 +103,42 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
 
 The sample implementation builds under POCL on x86 and demonstrates a number of buffering schemes.
 
-It builds using cmake and has been tested on Linux
+It builds using CMake and has been tested on Linux.
 
 ### CMake
 
-#### Tested Supported systems:
+#### Tested Supported Systems
 
 * Linux
 
-#### Pre-requisite:
+#### Requirements
 
-* python 2.x (Tested with python 2.7)
-* CMAKE 2.8.12 or higher. (should be in PATH)
+* Python 2.x (Tested with Python 2.7)
+* CMake 2.8.12 or higher (should be in PATH)
 
-#### Building Samples:
+#### Building the Samples
 
-    Install Pocl http://portablecl.org/docs/html/install.html or other environment of your choice.
-    Install pyopencl https://pypi.org/project/pyopencl/
+- Install [PoCL](http://portablecl.org/docs/html/install.html) or another environment of your choice.
+- Install [pyopencl](https://pypi.org/project/pyopencl/)
 
-    Linux:
-    ------
-    From shell:
+Execute the following commands:
 
-    > cd opencl/samples
-    > ./ttl_sample_runner.py *.cl
-    > cd ../c/samples
-    > ./ttl_sample_runner.py *.c
+```sh
+$ cd opencl/samples
+$ ./ttl_sample_runner.py *.cl
+$ cd ../c/samples
+$ ./ttl_sample_runner.py *.c
+```
 
-#### Install:
+#### Installation
 
-    See INSTALL file
+See [INSTALL](./INSTALL).
 
 ## Included Unit Tests
 
-    See opencl/test/README.md
+See [the test README](./opencl/test/).
 
 
 ## Bug Reporting
 
-Bug reports can be reported by filing an [issue on the GitHub](https://github.com/KhronosGroup/OpenCL-TTL/issues)
+Bug reports can be reported by filing an [issue on GitHub](https://github.com/KhronosGroup/OpenCL-TTL/issues).

--- a/c/samples/TTL_sample_runner.py
+++ b/c/samples/TTL_sample_runner.py
@@ -24,11 +24,12 @@ import os
 import sys
 import random
 
+
 def TestTTL(program_name):
-    os.environ['PYOPENCL_COMPILER_OUTPUT'] = '1'
-    os.environ['PYOPENCL_CTX'] = '0'
+    os.environ["PYOPENCL_COMPILER_OUTPUT"] = "1"
+    os.environ["PYOPENCL_CTX"] = "0"
     os.environ["PYOPENCL_NO_CACHE"] = "1"
-    
+
     # Allow an environment variable to provide the TTL_INCLUDE_PATH, if not defined regular paths used.
     if "TTL_INCLUDE_PATH" in os.environ:
         ttl_include_path = "-I" + os.environ["TTL_INCLUDE_PATH"]
@@ -38,24 +39,53 @@ def TestTTL(program_name):
     # For convenience remove any extension if it included.
     program_name = os.path.splitext(os.path.basename(program_name))[0]
 
-    compile_string = "rm -f " + program_name +".so; clang " + ttl_include_path + " -DKERNEL_NAME=" + program_name +" -DTTL_TARGET=c -fPIC -shared -o " + program_name +".so " + program_name + ".c"
+    compile_string = (
+        "rm -f "
+        + program_name
+        + ".so; clang "
+        + ttl_include_path
+        + " -DKERNEL_NAME="
+        + program_name
+        + " -DTTL_TARGET=c -fPIC -shared -o "
+        + program_name
+        + ".so "
+        + program_name
+        + ".c"
+    )
     os.system(compile_string)
     c_lib = ctypes.CDLL(pathlib.Path().absolute() / (program_name + ".so"))
 
     # For variation a number of tensor random sizes are used, then tiled with random tile sizes
     for tensor_width in random.sample(range(1, 125), 15):
         for tensor_height in random.sample(range(1, 125), 15):
-            output_data = bytearray(os.urandom(tensor_width * tensor_height  + 0))
-            input_data = bytearray(os.urandom(tensor_width * tensor_height  + 1))
+            output_data = bytearray(os.urandom(tensor_width * tensor_height + 0))
+            input_data = bytearray(os.urandom(tensor_width * tensor_height + 1))
 
-            input_buffer = ctypes.create_string_buffer(bytes(input_data), len(input_data));
-            output_buffer = ctypes.create_string_buffer(bytes(output_data), len(output_data));
+            input_buffer = ctypes.create_string_buffer(
+                bytes(input_data), len(input_data)
+            )
+            output_buffer = ctypes.create_string_buffer(
+                bytes(output_data), len(output_data)
+            )
 
-            for tile_width in [1, tensor_width] + random.sample(range(1, tensor_width+30), 15):
-                for tile_height in [1, tensor_height] + random.sample(range(1, tensor_height+30), 15):
+            for tile_width in [1, tensor_width] + random.sample(
+                range(1, tensor_width + 30), 15
+            ):
+                for tile_height in [1, tensor_height] + random.sample(
+                    range(1, tensor_height + 30), 15
+                ):
                     error = False
 
-                    getattr(c_lib, program_name)(input_buffer, tensor_width, output_buffer, tensor_width, tensor_width, tensor_height, tile_width, tile_height)
+                    getattr(c_lib, program_name)(
+                        input_buffer,
+                        tensor_width,
+                        output_buffer,
+                        tensor_width,
+                        tensor_width,
+                        tensor_height,
+                        tile_width,
+                        tile_height,
+                    )
 
                     return_buffer = bytearray(output_buffer.raw)
 
@@ -64,31 +94,54 @@ def TestTTL(program_name):
                             expected = 0
 
                             if j > 0:
-                                expected += input_data[i * tensor_width + (j - 1)];
-                            if i  > 0:
-                                expected += input_data[(i -1 )* tensor_width + j];
+                                expected += input_data[i * tensor_width + (j - 1)]
+                            if i > 0:
+                                expected += input_data[(i - 1) * tensor_width + j]
 
-                            expected += input_data[i * tensor_width + j];
+                            expected += input_data[i * tensor_width + j]
 
                             if j < (tensor_width - 1):
                                 expected += input_data[i * tensor_width + (j + 1)]
                             if i < (tensor_height - 1):
                                 expected += input_data[(i + 1) * tensor_width + j]
-                                
-                            expected &= 0xff
+
+                            expected &= 0xFF
 
                             if return_buffer[i * tensor_width + j] != expected:
-                                print("%s Failed at [%d, %d] %d != %d Tensor size [%d, %d], Tile size [%d, %d]" %(program_name, j, i, return_buffer[i * tensor_width + j], expected, tensor_width, tensor_height, tile_width, tile_height))
+                                print(
+                                    "%s Failed at [%d, %d] %d != %d Tensor size [%d, %d], Tile size [%d, %d]"
+                                    % (
+                                        program_name,
+                                        j,
+                                        i,
+                                        return_buffer[i * tensor_width + j],
+                                        expected,
+                                        tensor_width,
+                                        tensor_height,
+                                        tile_width,
+                                        tile_height,
+                                    )
+                                )
                                 error = True
                                 exit(-1)
-                    
+
                     if error:
                         exit(-1)
 
-                    print("%s Passed Tensor size [%d, %d] Tile size [%d, %d]" %(program_name, tensor_width, tensor_height, tile_width, tile_height))
+                    print(
+                        "%s Passed Tensor size [%d, %d] Tile size [%d, %d]"
+                        % (
+                            program_name,
+                            tensor_width,
+                            tensor_height,
+                            tile_width,
+                            tile_height,
+                        )
+                    )
 
-    os.system("rm -f " + program_name +".so")
+    os.system("rm -f " + program_name + ".so")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     for program_name in sys.argv[1:]:
         TestTTL(program_name)

--- a/c/samples/TTL_sample_runner.py
+++ b/c/samples/TTL_sample_runner.py
@@ -63,20 +63,17 @@ def TestTTL(program_name):
                         for j in range(0, tensor_width):
                             expected = 0
 
-                            if True:
-                                if j > 0:
-                                    expected += input_data[i * tensor_width + (j - 1)];
-                                if i  > 0:
-                                    expected += input_data[(i -1 )* tensor_width + j];
+                            if j > 0:
+                                expected += input_data[i * tensor_width + (j - 1)];
+                            if i  > 0:
+                                expected += input_data[(i -1 )* tensor_width + j];
 
-                                expected += input_data[i * tensor_width + j];
+                            expected += input_data[i * tensor_width + j];
 
-                                if j < (tensor_width - 1):
-                                    expected += input_data[i * tensor_width + (j + 1)]
-                                if i < (tensor_height - 1):
-                                    expected += input_data[(i + 1) * tensor_width + j]
-                            else:
-                                expected = (input_data[i * tensor_width + j] + 1) * (input_data[i * tensor_width + j] + 2) * (input_data[i * tensor_width + j] + 3)
+                            if j < (tensor_width - 1):
+                                expected += input_data[i * tensor_width + (j + 1)]
+                            if i < (tensor_height - 1):
+                                expected += input_data[(i + 1) * tensor_width + j]
                                 
                             expected &= 0xff
 

--- a/c/samples/TTL_sample_runner.py
+++ b/c/samples/TTL_sample_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # ttl_sample_runner.py
 #

--- a/opencl/samples/TTL_sample_runner.py
+++ b/opencl/samples/TTL_sample_runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # ttl_sample_runner.py
 #

--- a/opencl/samples/TTL_sample_runner.py
+++ b/opencl/samples/TTL_sample_runner.py
@@ -66,20 +66,17 @@ def TestTTL(program_name):
                         for j in range(0, tensor_width):
                             expected = 0
 
-                            if True:
-                                if j > 0:
-                                    expected += input_data[i * tensor_width + (j - 1)];
-                                if i  > 0:
-                                    expected += input_data[(i -1 )* tensor_width + j];
+                            if j > 0:
+                                expected += input_data[i * tensor_width + (j - 1)];
+                            if i  > 0:
+                                expected += input_data[(i -1 )* tensor_width + j];
 
-                                expected += input_data[i * tensor_width + j];
+                            expected += input_data[i * tensor_width + j];
 
-                                if j < (tensor_width - 1):
-                                    expected += input_data[i * tensor_width + (j + 1)]
-                                if i < (tensor_height - 1):
-                                    expected += input_data[(i + 1) * tensor_width + j]
-                            else:
-                                expected = (input_data[i * tensor_width + j] + 1) * (input_data[i * tensor_width + j] + 2) * (input_data[i * tensor_width + j] + 3)
+                            if j < (tensor_width - 1):
+                                expected += input_data[i * tensor_width + (j + 1)]
+                            if i < (tensor_height - 1):
+                                expected += input_data[(i + 1) * tensor_width + j]
                                 
                             expected &= 0xff
 

--- a/opencl/samples/TTL_sample_runner.py
+++ b/opencl/samples/TTL_sample_runner.py
@@ -22,9 +22,10 @@ import os
 import sys
 import random
 
+
 def TestTTL(program_name):
-    os.environ['PYOPENCL_COMPILER_OUTPUT'] = '1'
-    os.environ['PYOPENCL_CTX'] = '0'
+    os.environ["PYOPENCL_COMPILER_OUTPUT"] = "1"
+    os.environ["PYOPENCL_CTX"] = "0"
     os.environ["PYOPENCL_NO_CACHE"] = "1"
 
     # Allow an environment variable to provide the TTL_INCLUDE_PATH, if not defined regular paths used.
@@ -38,27 +39,55 @@ def TestTTL(program_name):
 
     # For convenience remove the .cl extension if it included.
     program_name = os.path.splitext(program_name)[0]
-    program = cl.Program(context, open(program_name+'.cl').read()).build(options=ttl_include_path + " -D__TTL_VERSION__=04 -DTTL_COPY_3D")
+    program = cl.Program(context, open(program_name + ".cl").read()).build(
+        options=ttl_include_path + " -D__TTL_VERSION__=04 -DTTL_COPY_3D"
+    )
 
     # For variation a number of tensor random sizes are used, then tiled with random tile sizes
     for tensor_width in random.sample(range(1, 125), 3):
         for tensor_height in random.sample(range(1, 125), 3):
 
-            input_data = numpy.random.randint(256, size = tensor_width * tensor_height).astype(numpy.uint8)
-            output_data = numpy.random.randint(256, size = tensor_width * tensor_height).astype(numpy.uint8)
+            input_data = numpy.random.randint(
+                256, size=tensor_width * tensor_height
+            ).astype(numpy.uint8)
+            output_data = numpy.random.randint(
+                256, size=tensor_width * tensor_height
+            ).astype(numpy.uint8)
 
             for i in range(0, tensor_height):
                 for j in range(0, tensor_width):
                     input_data[i * tensor_width + j] = j
 
-            input_buffer = cl.Buffer(context, cl.mem_flags.READ_ONLY  | cl.mem_flags.COPY_HOST_PTR , hostbuf=input_data)
-            output_buffer = cl.Buffer(context, cl.mem_flags.READ_WRITE, output_data.nbytes)
+            input_buffer = cl.Buffer(
+                context,
+                cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR,
+                hostbuf=input_data,
+            )
+            output_buffer = cl.Buffer(
+                context, cl.mem_flags.READ_WRITE, output_data.nbytes
+            )
 
-            for tile_width in [1, tensor_width] + random.sample(range(1, tensor_width+30), 3):
-                for tile_height in [1, tensor_height] + random.sample(range(1, tensor_height+30), 3):
+            for tile_width in [1, tensor_width] + random.sample(
+                range(1, tensor_width + 30), 3
+            ):
+                for tile_height in [1, tensor_height] + random.sample(
+                    range(1, tensor_height + 30), 3
+                ):
                     error = False
 
-                    getattr(program, program_name)(queue, (1,), None, input_buffer, numpy.int32(tensor_width), output_buffer, numpy.int32(tensor_width), numpy.int32(tensor_width), numpy.int32(tensor_height), numpy.int32(tile_width), numpy.int32(tile_height))
+                    getattr(program, program_name)(
+                        queue,
+                        (1,),
+                        None,
+                        input_buffer,
+                        numpy.int32(tensor_width),
+                        output_buffer,
+                        numpy.int32(tensor_width),
+                        numpy.int32(tensor_width),
+                        numpy.int32(tensor_height),
+                        numpy.int32(tile_width),
+                        numpy.int32(tile_height),
+                    )
 
                     cl.enqueue_copy(queue, output_data, output_buffer)
 
@@ -67,29 +96,52 @@ def TestTTL(program_name):
                             expected = 0
 
                             if j > 0:
-                                expected += input_data[i * tensor_width + (j - 1)];
-                            if i  > 0:
-                                expected += input_data[(i -1 )* tensor_width + j];
+                                expected += input_data[i * tensor_width + (j - 1)]
+                            if i > 0:
+                                expected += input_data[(i - 1) * tensor_width + j]
 
-                            expected += input_data[i * tensor_width + j];
+                            expected += input_data[i * tensor_width + j]
 
                             if j < (tensor_width - 1):
                                 expected += input_data[i * tensor_width + (j + 1)]
                             if i < (tensor_height - 1):
                                 expected += input_data[(i + 1) * tensor_width + j]
-                                
-                            expected &= 0xff
+
+                            expected &= 0xFF
 
                             if output_data[i * tensor_width + j] != expected:
-                                print("%s Failed at [%d, %d] %d != %d Tensor size [%d, %d], Tile size [%d, %d]" %(program_name, j, i, output_data[i * tensor_width + j], expected, tensor_width, tensor_height, tile_width, tile_height))
+                                print(
+                                    "%s Failed at [%d, %d] %d != %d Tensor size [%d, %d], Tile size [%d, %d]"
+                                    % (
+                                        program_name,
+                                        j,
+                                        i,
+                                        output_data[i * tensor_width + j],
+                                        expected,
+                                        tensor_width,
+                                        tensor_height,
+                                        tile_width,
+                                        tile_height,
+                                    )
+                                )
                                 error = True
                                 exit(-1)
-                    
+
                     if error:
                         exit(-1)
 
-                    print("%s Passed Tensor size [%d, %d] Tile size [%d, %d]" %(program_name, tensor_width, tensor_height, tile_width, tile_height))
+                    print(
+                        "%s Passed Tensor size [%d, %d] Tile size [%d, %d]"
+                        % (
+                            program_name,
+                            tensor_width,
+                            tensor_height,
+                            tile_width,
+                            tile_height,
+                        )
+                    )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     for program_name in sys.argv[1:]:
         TestTTL(program_name)


### PR DESCRIPTION
Changes:
- Update README (syntax highlighting, formatting)
- Remove dead code (`if True` in sample runners)
- Use `black` to format the python runners (to make single quotes and double quotes consistent, among other things)

Additional Suggestions:
- Move headers into a TTL directory so running the samples without installing will only require changing the `TTL_INCLUDE_PATH` (assuming the repository is cloned into a directory not called TTL but OpenCL-TTL)
    - Without installing the library, was able to succesfully run the samples on Arch Linux with Python 3.10 (without CMake) by changing the root directory from OpenCL-TTL to TTL and then specifying `TTL_INCLUDE_PATH=../../..`
- Mark the library as header only in the README