### PR TITLE
Add TTL_fetch_tensor and some cpp samples to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
     }
 
     // These wait for the last transfers to complete.
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
 }
 ```
 

--- a/TTL_tensors.h
+++ b/TTL_tensors.h
@@ -20,3 +20,12 @@
 
 #include "tensors/TTL_ext_tensors.h"
 #include "tensors/TTL_int_tensors.h"
+
+
+#ifndef FROM_C
+void TTL_fetch_tensor(__local TTL_ext_tensor_t *local_ext_tensor, const __global TTL_ext_tensor_t *global_ext_tensor) {
+    event_t event = async_work_group_copy(
+        (__local uchar *)local_ext_tensor, (const __global uchar *)global_ext_tensor, sizeof(*local_ext_tensor), 0);
+    wait_group_events(1, &event);
+}
+#endif

--- a/TTL_trace_macros.h
+++ b/TTL_trace_macros.h
@@ -39,16 +39,13 @@
 #define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
 
 #define TTL_start_simplex_buffering(...) TTL_start_simplex_buffering(__VA_ARGS__, __LINE__)
-#define TTL_finish_simplex_buffering(...) TTL_finish_simplex_buffering(__VA_ARGS__, __LINE__)
+#define TTL_finish_buffering(...) TTL_finish_buffering(__VA_ARGS__, __LINE__)
 
 #define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
 
 #define TTL_start_import_double_buffering(...) TTL_start_import_double_buffering(__VA_ARGS__)
-#define TTL_finish_import_double_buffering(...) TTL_finish_import_double_buffering(__VA_ARGS__, __LINE__)
 
 #define TTL_start_export_double_buffering(...) TTL_start_export_double_buffering(__VA_ARGS__, __LINE__)
-#define TTL_finish_export_double_buffering(...) TTL_finish_export_double_buffering(__VA_ARGS__, __LINE__)
 
 #define TTL_start_duplex_buffering(...) TTL_start_duplex_buffering(__VA_ARGS__, __LINE__)
-#define TTL_finish_duplex_buffering(...) TTL_finish_duplex_buffering(__VA_ARGS__, __LINE__)
 #endif

--- a/c/samples/TTL_double_buffering.c
+++ b/c/samples/TTL_double_buffering.c
@@ -73,8 +73,8 @@ void TTL_double_buffering(unsigned char *restrict ext_base_in, int external_stri
         compute(imported_to, exported_from);
     }
 
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
 
     result_check(ext_base_in, ext_base_out, width, height, tile_width, tile_height);
 }

--- a/c/samples/TTL_duplex_buffering.c
+++ b/c/samples/TTL_duplex_buffering.c
@@ -69,5 +69,5 @@ void TTL_duplex_buffering(unsigned char *restrict ext_base_in, int external_stri
     }
 
     // This waits for the last transfers to complete.
-    TTL_finish_duplex_buffering(&duplex_scheme);
+    TTL_finish_buffering(&duplex_scheme);
 }

--- a/c/samples/TTL_simplex_buffering.c
+++ b/c/samples/TTL_simplex_buffering.c
@@ -71,7 +71,7 @@ void TTL_simplex_buffering(unsigned char *restrict ext_base_in, int external_str
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_simplex_buffering(&simplex_scheme);
+    TTL_finish_buffering(&simplex_scheme);
 
     result_check(ext_base_in, ext_base_out, width, height, tile_width, tile_height);
 }

--- a/opencl/samples/README.md
+++ b/opencl/samples/README.md
@@ -2,44 +2,10 @@
 
 These OpenCL Samples allow for a host only build, debug, and validation of the TTL library. A key ingredient is the ease of build and ease of debug.
 
-## Basis
-
-The samples can be built and testing using a  Python wrapper.
-
 ## Executing the Samples
 
 Install the TTL include files as described in [INSTALL](../../INSTALL)
 Install an OpenCL environment such a POCL. The tests were carried out with POCL.
 
-## Python Wrapper
-
-    ./TTL_sample_runner.py TTL_double_buffering.cl
-
-The name can be wildcarded
-
-    ./TTL_sample_runner.py TTL_*.cl
-
-## The "Kernel"
-
-The kernel is a simple sum of a cross of the input.
-
-Given an input tensor I of size X * Y
-
-The output tensor O is
-
-    O[0,0] = I[0,0]+I[-1,0]+I[+1,0]+I[0,+1]+I[0,-1]
-
-or
-
-    for y = 0 to Y:
-      for x = 0 to X:
-        O[y,x] = I[y,x]+I[y-1,x]+I[y+1,x]+I[y,x+1]+I[y,x-1]
-
-At the edges of the input [-1,0] for example a zero value is augmented meaning that the input tensor the kernel receives
-is effectively bigger than the actual input tensor with the augmentation being zero values.
-
-The TTL_sample_runner.py based tests run through a random set of tensor and tile sizes, with an augmentation of 1 - providing
-a fairly broad-based testing.
-
-The compute.h file which contains the calculations. A checker function in the ./TTL_sample_runner.py file validates the tiled calculation.
-  
+See opencl/samples/python/README.md for some python based examples.
+See opencl/samples/cpp/README.md for some cpp based examples.

--- a/opencl/samples/cpp/README.md
+++ b/opencl/samples/cpp/README.md
@@ -1,0 +1,46 @@
+# CPP OpenCL Samples for the Tensor Tiling Library (TTL)
+
+See opencl/samples/README.md for overview
+
+## Basis
+
+The samples can be built and testing using a CPP host executable
+
+## CPP Wrapper
+
+Two examples exist, the first is a overlapping tiling example, the second a simple tiling copy example.
+
+A key to these samples is that Tensors are used on the Host and the Device side.
+
+Compile as follows
+
+```
+export TTL_INCLUDE_PATH=[PATH TO TTL]
+clang -O0 -g -D TTL_TARGET=c -D KERNEL_NAME=TTL_sample_overlap -D CHECKER_NAME=\"check_cross.h\" -D CL_TARGET_OPENCL_VERSION=300 -I /localdisk/cgearing/ -I /localdisk/cgearing/pocl/include -o TTL_sample_overlap TTL_sample_runner.cpp -lOpenCL -lstdc++
+clang -O0 -g -D TTL_TARGET=c -D KERNEL_NAME=TTL_sample_simple_duplex -D CHECKER_NAME=\"check_square.h\" -D CL_TARGET_OPENCL_VERSION=300 -I /localdisk/cgearing/ -I /localdisk/cgearing/pocl/include -o TTL_sample_simple_duplex TTL_sample_runner.cpp -lOpenCL -lstdc++
+clang -O0 -g -D TTL_TARGET=c -D KERNEL_NAME=TTL_sample_simple_double -D CHECKER_NAME=\"check_square.h\" -D CL_TARGET_OPENCL_VERSION=300 -I /localdisk/cgearing/ -I /localdisk/cgearing/pocl/include -o TTL_sample_simple_double TTL_sample_runner.cpp -lOpenCL -lstdc++
+```
+
+## The "Cross Kernel" is described in 
+
+The "Cross Kernel" is described in  opencl/samples/python/README.md
+
+## The "Square Kernel"
+
+The kernel is a simple sqr of the input to the output.
+
+Given an input tensor I of size X * Y
+
+The output tensor O is
+
+    O[0,0] = I[0,0]^2
+
+or
+
+    for y = 0 to Y:
+      for x = 0 to X:
+        O[y,x] = I[y,x]^2
+
+
+For kernel two includes files exist - compute_XXXX.h and check_XXXX.h (XXXX is square or cross). The compute is used by the
+kernel and the check is used by the host code

--- a/opencl/samples/cpp/TTL_sample_overlap.cl
+++ b/opencl/samples/cpp/TTL_sample_overlap.cl
@@ -1,0 +1,65 @@
+/*
+ * ttl_duplex_buffering.cl
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TTL/TTL.h"
+#include "compute_cross.h"
+
+#define TILE_SIZE 0x8000
+#define TILE_WIDTH 10
+#define TILE_HEIGHT 10
+
+__kernel void TTL_sample_overlap(const __global TTL_ext_tensor_t *ptr_ext_input_tensor,
+                                   const __global TTL_ext_tensor_t *ptr_ext_output_tensor) {
+    __local TTL_ext_tensor_t ext_input_tensor, ext_output_tensor;
+    __local uchar l_in[TILE_SIZE], l_out[TILE_SIZE];
+
+    TTL_fetch_tensor(&ext_input_tensor, ptr_ext_input_tensor);
+    TTL_fetch_tensor(&ext_output_tensor, ptr_ext_output_tensor);
+
+    // Logical input tiling.
+    const TTL_shape_t tile_shape_in = TTL_create_shape(TILE_WIDTH + (TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT),
+                                                       TILE_HEIGHT + (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM));
+    const TTL_overlap_t overlap_in =
+        TTL_create_overlap(TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT, TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM);
+    const TTL_augmentation_t augmentation_in =
+        TTL_create_augmentation(TILE_OVERLAP_LEFT, TILE_OVERLAP_RIGHT, TILE_OVERLAP_TOP, TILE_OVERLAP_BOTTOM);
+    const TTL_tiler_t input_tiler =
+        TTL_create_overlap_tiler(ext_input_tensor.shape, tile_shape_in, overlap_in, augmentation_in);
+
+    // Logical output tiling.
+    const TTL_tiler_t output_tiler = TTL_create_tiler(ext_input_tensor.shape, TTL_create_shape(TILE_WIDTH, TILE_HEIGHT));
+
+    // duplex_scheme must be defined outside, before the loop - because we "time-shift" the export to work on a recorded
+    // tile written to in previous iteration.
+    TTL_event_t sb_e_in_out[2] = { TTL_get_event(), TTL_get_event() };
+
+    TTL_duplex_buffering_t duplex_scheme = TTL_start_duplex_buffering(
+        ext_input_tensor, l_in, ext_output_tensor, l_out, &sb_e_in_out, TTL_get_tile(0, input_tiler));
+
+    for (int i = 0; i < TTL_number_of_tiles(input_tiler); ++i) {
+        TTL_tile_t tile_next_import = TTL_get_tile(i, input_tiler);
+        TTL_tile_t tile_current_export = TTL_get_tile(i, output_tiler);
+
+        // Import current tile, export previous tile and wait for both transactions.
+        TTL_io_tensors_t tensors = TTL_step_buffering(&duplex_scheme, tile_next_import, tile_current_export);
+
+        compute(tensors.imported_to, tensors.to_export_from);
+    }
+
+    TTL_finish_buffering(&duplex_scheme);
+}

--- a/opencl/samples/cpp/TTL_sample_runner.cpp
+++ b/opencl/samples/cpp/TTL_sample_runner.cpp
@@ -1,0 +1,219 @@
+/**********************************************************************
+Copyright ©2015 Advanced Micro Devices, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+•	Redistributions of source code must retain the above copyright notice, this list of conditions and the
+following disclaimer.
+•	Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+********************************************************************/
+// For clarity,error checking has been omitted.
+
+#include <OpenCL/cl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+
+#define FROM_C
+#include "TTL/TTL.h"
+#include CHECKER_NAME
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+#define SUCCESS 0
+#define FAILURE 1
+#define CHECK_STATUS(x)                                                      \
+    {                                                                        \
+        cl_int status = (x);                                                 \
+        if (status != 0) {                                                   \
+            cout << "Status: " << status << " at line " << __LINE__ << endl; \
+            return FAILURE;                                                  \
+        }                                                                    \
+    }
+using namespace std;
+
+/* convert the kernel file into a string */
+int convertToString(const char *filename, std::string &s) {
+    std::fstream f(filename, (std::fstream::in | std::fstream::binary));
+
+    if (f.is_open()) {
+        size_t size;
+        char *str;
+        size_t file_size;
+        f.seekg(0, std::fstream::end);
+        size = file_size = (size_t)f.tellg();
+        f.seekg(0, std::fstream::beg);
+        str = new char[size + 1];
+        if (!str) {
+            f.close();
+            return 0;
+        }
+
+        f.read(str, file_size);
+        f.close();
+        str[size] = '\0';
+        s = str;
+        delete[] str;
+        return 0;
+    }
+    cout << "Error: failed to open file\n:" << filename << endl;
+    return FAILURE;
+}
+
+int main(int argc, char *argv[]) {
+    /* Step1: Getting platforms and choose an available one.*/
+    cl_uint numPlatforms;            // the NO. of platforms
+    cl_platform_id platform = NULL;  // the chosen platform
+    CHECK_STATUS(clGetPlatformIDs(0, NULL, &numPlatforms));
+
+    /*For clarity, choose the first available platform. */
+    if (numPlatforms > 0) {
+        cl_platform_id *platforms = (cl_platform_id *)malloc(numPlatforms * sizeof(cl_platform_id));
+        CHECK_STATUS(clGetPlatformIDs(numPlatforms, platforms, NULL));
+        platform = platforms[0];
+        free(platforms);
+    }
+
+    /* Step 2:Query the platform and choose the first GPU device if has one.Otherwise use the CPU as device.*/
+    cl_uint num_devices = 0;
+    cl_device_id *devices;
+    clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 0, NULL, &num_devices);
+
+    if (num_devices == 0)  // no GPU available.
+    {
+        cout << "No GPU device available." << endl;
+        cout << "Choose CPU as default device." << endl;
+        CHECK_STATUS(clGetDeviceIDs(platform, CL_DEVICE_TYPE_CPU, 0, NULL, &num_devices));
+        devices = (cl_device_id *)malloc(num_devices * sizeof(cl_device_id));
+        CHECK_STATUS(clGetDeviceIDs(platform, CL_DEVICE_TYPE_CPU, num_devices, devices, NULL));
+    } else {
+        devices = (cl_device_id *)malloc(num_devices * sizeof(cl_device_id));
+        CHECK_STATUS(clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, num_devices, devices, NULL));
+    }
+
+    /* Step 3: Create context.*/
+    cl_context context = clCreateContext(NULL, 1, devices, NULL, NULL, NULL);
+
+    /* Step 4: Creating command queue associate with the context.*/
+    cl_command_queue commandQueue = clCreateCommandQueueWithProperties(context, devices[0], NULL, NULL);
+
+    /* Step 5: Create program object */
+    string source_string;
+    CHECK_STATUS(convertToString(xstr(KERNAL_SOURCE_NAME), source_string));
+    const char *source = source_string.c_str();
+    size_t source_size[] = { strlen(source) };
+    cl_program program = clCreateProgramWithSource(context, 1, &source, source_size, NULL);
+
+    /* Step 6: Build program. */
+    if (clBuildProgram(
+            program, 1, devices, "-I /localdisk/cgearing/ -D TTL_COPY_3D", NULL, NULL) !=
+        0) {
+        size_t size;
+
+        // main code
+        clGetProgramBuildInfo(program, devices[0], CL_PROGRAM_BUILD_LOG, 0, NULL, &size);
+
+        char *build_log = new char[size + 1];
+
+        clGetProgramBuildInfo(program, devices[0], CL_PROGRAM_BUILD_LOG, size, build_log, NULL);
+        cout << endl << endl << "Buildlog:   " << build_log << endl << endl;
+        delete[] build_log;
+        exit(-1);
+    }
+
+    /* Step 7: Initial input,output for the host and create memory objects for the kernel*/
+    constexpr uint32_t input_width = 100;
+    constexpr uint32_t input_height = 250;
+    unsigned char *input = (unsigned char *)malloc(input_width * input_height);
+
+    constexpr uint32_t output_width = 100;
+    constexpr uint32_t output_height = 250;
+    unsigned char *output = (unsigned char *)malloc(output_width * output_height);
+
+    constexpr uint32_t cout_len = 2048;
+    unsigned char *cout_buffer = (unsigned char *)malloc(cout_len * sizeof(unsigned char));
+
+    for (int x = 0; x < sizeof(input_width * input_height); x++) {
+        input[x] = rand();
+        output[x] = rand();
+    }
+
+    cl_mem outputBuffer = clCreateBuffer(
+        context, CL_MEM_WRITE_ONLY , cout_len * sizeof(char), (void *)NULL, NULL);
+
+    const TTL_shape_t tensor_shape_in = TTL_create_shape(input_width, input_height);
+    const TTL_shape_t tensor_shape_out = TTL_create_shape(input_width, input_height);
+    const TTL_layout_t ext_layout_in = TTL_create_layout(input_width);
+    const TTL_layout_t ext_layout_out = TTL_create_layout(input_width);
+    const TTL_ext_tensor_t ext_input_tensor = TTL_create_ext_tensor(input, tensor_shape_in, ext_layout_in) ;
+    const TTL_ext_tensor_t ext_output_tensor = TTL_create_ext_tensor(output, tensor_shape_out, ext_layout_out);
+
+    cl_int error_code_ret;
+    cl_mem ext_input_tensor_mem = clCreateBuffer(context,
+                                        CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+                                        sizeof(ext_input_tensor),
+                                        (void *)&ext_input_tensor,
+                                        &error_code_ret);
+    cl_mem ext_output_tensor_mem = clCreateBuffer(context,
+                                        CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+                                        sizeof(ext_output_tensor),
+                                        (void *)&ext_output_tensor,
+                                        &error_code_ret);
+  
+    /* Step 8: Create kernel object */
+    cl_kernel kernel = clCreateKernel(program, xstr(KERNEL_NAME), NULL);
+
+    /* Step 9: Sets Kernel arguments.*/
+    int arg = 0;
+    CHECK_STATUS(clSetKernelArg(kernel, arg++, sizeof(cl_mem), (void *)&ext_input_tensor_mem));
+    CHECK_STATUS(clSetKernelArg(kernel, arg++, sizeof(cl_mem), (void *)&ext_output_tensor_mem));
+
+    /* Step 10: Running the kernel.*/
+    size_t global_work_size[1] = { 1 };
+    CHECK_STATUS(clEnqueueNDRangeKernel(commandQueue, kernel, 1, NULL, global_work_size, NULL, 0, NULL, NULL));
+
+    /* Step 11: Read the cout put back to host memory.*/
+    CHECK_STATUS(clEnqueueReadBuffer(
+        commandQueue, outputBuffer, CL_TRUE, 0, cout_len * sizeof(char), cout_buffer, 0, NULL, NULL));
+
+    std::cout << (result_check(input, output, input_width, input_height)?"Passed!":"Failed") << endl;
+
+    /* Step 12: Clean the resources.*/
+    CHECK_STATUS(clReleaseKernel(kernel));          // Release kernel.
+    CHECK_STATUS(clReleaseProgram(program));        // Release the program object.
+    CHECK_STATUS(clReleaseMemObject(outputBuffer));
+    CHECK_STATUS(clReleaseCommandQueue(commandQueue));  // Release  Command queue.
+    CHECK_STATUS(clReleaseContext(context));            // Release context.
+
+    if (input != NULL) {
+        free(input);
+        input = NULL;
+    }
+
+    if (output != NULL) {
+        free(output);
+        output = NULL;
+    }
+
+    if (devices != NULL) {
+        free(devices);
+        devices = NULL;
+    }
+
+    return SUCCESS;
+}

--- a/opencl/samples/cpp/TTL_sample_simple.cl
+++ b/opencl/samples/cpp/TTL_sample_simple.cl
@@ -1,0 +1,85 @@
+/*
+ * ttl_duplex_buffering.cl
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TTL/TTL.h"
+#include "compute_square.h"
+
+#define TILE_SIZE 0x8000
+#define TILE_WIDTH 10
+#define TILE_HEIGHT 10
+
+__kernel void TTL_sample_simple_duplex(const __global TTL_ext_tensor_t *ptr_ext_input_tensor,
+                                const __global TTL_ext_tensor_t *ptr_ext_output_tensor) {
+    __local TTL_ext_tensor_t ext_input_tensor, ext_output_tensor;
+    __local uchar l_in[TILE_SIZE], l_out[TILE_SIZE];
+
+    TTL_fetch_tensor(&ext_input_tensor, ptr_ext_input_tensor);
+    TTL_fetch_tensor(&ext_output_tensor, ptr_ext_output_tensor);
+
+    // Tiling depends only on logical shapes:
+    const TTL_shape_t tile_shape = TTL_create_shape(TILE_WIDTH, TILE_HEIGHT);
+    const TTL_tiler_t tiler = TTL_create_tiler(ext_input_tensor.shape, tile_shape);
+
+    TTL_event_t events[] = { TTL_get_event(), TTL_get_event() };
+
+    TTL_duplex_buffering_t duplex_scheme = TTL_start_duplex_buffering(
+        ext_input_tensor, l_in, ext_output_tensor, l_out, &events, TTL_get_tile(0, tiler));
+
+    for (int i = 0; i < TTL_number_of_tiles(tiler); ++i) {
+        const TTL_tile_t tile = TTL_get_tile(i, tiler);
+        TTL_io_tensors_t tensors = TTL_step_buffering(&duplex_scheme, tile, tile);
+        compute(tensors.imported_to, tensors.to_export_from);
+    }
+
+    TTL_finish_buffering(&duplex_scheme);
+}
+
+__kernel void TTL_sample_simple_double(const __global TTL_ext_tensor_t *ptr_ext_input_tensor,
+                                const __global TTL_ext_tensor_t *ptr_ext_output_tensor) {
+    __local TTL_const_ext_tensor_t ext_input_tensor;
+    __local TTL_ext_tensor_t ext_output_tensor;
+    __local uchar l_in1[TILE_SIZE], l_in2[TILE_SIZE], l_out1[TILE_SIZE], l_out2[TILE_SIZE];
+
+    TTL_fetch_tensor(&ext_input_tensor, ptr_ext_input_tensor);
+    TTL_fetch_tensor(&ext_output_tensor, ptr_ext_output_tensor);
+
+    // Tiling depends only on logical shapes:
+    const TTL_shape_t tile_shape = TTL_create_shape(TILE_WIDTH, TILE_HEIGHT);
+    const TTL_tiler_t tiler = TTL_create_tiler(ext_input_tensor.shape, tile_shape);
+
+    TTL_event_t import_event = TTL_get_event();
+    TTL_import_double_buffering_t import_db = TTL_start_import_double_buffering(
+        l_in1, l_in2, ext_input_tensor, &import_event, TTL_get_tile(0, tiler));
+
+    TTL_event_t export_event = TTL_get_event();
+    TTL_export_double_buffering_t export_db =
+        TTL_start_export_double_buffering(l_out1, l_out2, ext_output_tensor, &export_event);
+
+    for (int i = 0; i < TTL_number_of_tiles(tiler); ++i) {
+        TTL_tile_t t_next = TTL_get_tile(i + 1, tiler);
+        TTL_int_sub_tensor_t imported_to = TTL_step_buffering(&import_db, t_next);
+
+        TTL_tile_t t_current = TTL_get_tile(i, tiler);
+        TTL_int_sub_tensor_t exported_from = TTL_step_buffering(&export_db, t_current);
+
+        compute(imported_to, exported_from);
+    }
+
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
+}

--- a/opencl/samples/cpp/check_cross.h
+++ b/opencl/samples/cpp/check_cross.h
@@ -1,0 +1,54 @@
+/*
+ * compute_cross.h
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define KERNAL_SOURCE_NAME TTL_sample_overlap.cl
+
+bool result_check(unsigned char* const ext_base_in, unsigned char* const ext_base_out, const int width,
+                  const int height) {
+#define input_buffer ((uint8_t(*)[height][width])ext_base_in)
+#define output_buffer ((uint8_t(*)[height][width])ext_base_out)
+    bool result = true;
+
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            unsigned char expected;
+            expected = 0;
+
+            if (x > 0) expected += input_buffer[0][y][x - 1];
+            if (y > 0) expected += input_buffer[0][y - 1][x];
+
+            expected += input_buffer[0][y][x];
+
+            if (x < (width - 1)) expected += input_buffer[0][y][x + 1];
+            if (y < (height - 1)) expected += input_buffer[0][y + 1][x];
+
+            if (output_buffer[0][y][x] != expected) {
+                printf("Mismatch at [%d, %d] %d != %d Tensor size [%d, %d]\n",
+                       x,
+                       y,
+                       output_buffer[0][y][x],
+                       expected,
+                       width,
+                       height);
+                       result = false;
+            }
+        }
+    }
+
+    return result;
+}

--- a/opencl/samples/cpp/check_square.h
+++ b/opencl/samples/cpp/check_square.h
@@ -1,0 +1,45 @@
+/*
+ * compute_cross.h
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define KERNAL_SOURCE_NAME TTL_sample_simple.cl
+
+bool result_check(unsigned char* const ext_base_in, unsigned char* const ext_base_out, const int width,
+                  const int height) {
+#define input_buffer ((uint8_t(*)[height][width])ext_base_in)
+#define output_buffer ((uint8_t(*)[height][width])ext_base_out)
+    bool result = true;
+
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            unsigned char expected = input_buffer[0][y][x]^2;
+
+            if (output_buffer[0][y][x] !=expected) {
+                printf("Mismatch at [%d, %d] %d != %d Tensor size [%d, %d]\n",
+                       x,
+                       y,
+                       output_buffer[0][y][x],
+                       expected,
+                       width,
+                       height);
+                       result = false;
+            }
+        }
+    }
+
+    return result;
+}

--- a/opencl/samples/cpp/compute_cross.h
+++ b/opencl/samples/cpp/compute_cross.h
@@ -24,8 +24,8 @@
 #define TILE_OVERLAP_BOTTOM 1
 
 void compute(TTL_int_sub_tensor_t tensor_in, TTL_int_sub_tensor_t tensor_out) {
-    __local const unsigned char* const l_in = tensor_in.tensor.base;
-    __local unsigned char* const l_out = tensor_out.tensor.base;
+    __local const unsigned char* const restrict l_in = tensor_in.tensor.base;
+    __local unsigned char* const restrict l_out = tensor_out.tensor.base;
 
     const int x_shift = tensor_out.origin.sub_offset.x - tensor_in.origin.sub_offset.x;
     const int y_shift = tensor_out.origin.sub_offset.y - tensor_in.origin.sub_offset.y;

--- a/opencl/samples/cpp/compute_square.h
+++ b/opencl/samples/cpp/compute_square.h
@@ -1,0 +1,31 @@
+/*
+ * compute_cross.h
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TTL/TTL.h"
+
+void compute(TTL_int_sub_tensor_t tensor_in, TTL_int_sub_tensor_t tensor_out) {
+    __local const unsigned char* const restrict l_in = (__local const unsigned char*)tensor_in.tensor.base;
+    __local unsigned char* const restrict l_out = (__local unsigned char*)tensor_out.tensor.base;
+
+    for (int y = 0; y < tensor_out.tensor.shape.height; ++y) {
+        for (int x = 0; x < tensor_out.tensor.shape.width; ++x) {
+            l_out[(y * tensor_in.tensor.layout.row_spacing) + (x)] =
+                l_in[(y * tensor_out.tensor.layout.row_spacing) + (x)]^2;
+        }
+    }
+}

--- a/opencl/samples/python/README.md
+++ b/opencl/samples/python/README.md
@@ -1,0 +1,40 @@
+# Python OpenCL Samples for the Tensor Tiling Library (TTL)
+
+See opencl/samples/README.md for overview
+
+## Basis
+
+The samples can be built and testing using a Python host executable
+
+## Python Wrapper
+
+    ./TTL_sample_runner.py TTL_double_buffering.cl
+
+The name can be wildcarded
+
+    ./TTL_sample_runner.py TTL_*.cl
+
+## The "Kernel"
+
+The kernel is a simple sum of a cross of the input.
+
+Given an input tensor I of size X * Y
+
+The output tensor O is
+
+    O[0,0] = I[0,0]+I[-1,0]+I[+1,0]+I[0,+1]+I[0,-1]
+
+or
+
+    for y = 0 to Y:
+      for x = 0 to X:
+        O[y,x] = I[y,x]+I[y-1,x]+I[y+1,x]+I[y,x+1]+I[y,x-1]
+
+At the edges of the input [-1,0] for example a zero value is augmented meaning that the input tensor the kernel receives
+is effectively bigger than the actual input tensor with the augmentation being zero values.
+
+The TTL_sample_runner.py based tests run through a random set of tensor and tile sizes, with an augmentation of 1 - providing
+a fairly broad-based testing.
+
+The compute.h file which contains the calculations. A checker function in the ./TTL_sample_runner.py file validates the tiled calculation.
+  

--- a/opencl/samples/python/TTL_duplex_buffering.cl
+++ b/opencl/samples/python/TTL_duplex_buffering.cl
@@ -66,7 +66,5 @@ __kernel void TTL_duplex_buffering(__global uchar *restrict ext_base_in, int ext
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    // This waits for the last transfers to complete.
-    TTL_finish_duplex_buffering(&duplex_scheme);
-
+    TTL_finish_buffering(&duplex_scheme);
 }

--- a/opencl/samples/python/TTL_sample_runner.py
+++ b/opencl/samples/python/TTL_sample_runner.py
@@ -40,7 +40,7 @@ def TestTTL(program_name):
     # For convenience remove the .cl extension if it included.
     program_name = os.path.splitext(program_name)[0]
     program = cl.Program(context, open(program_name + ".cl").read()).build(
-        options=ttl_include_path + " -D__TTL_VERSION__=04 -DTTL_COPY_3D"
+        options=ttl_include_path + " -DTTL_COPY_3D"
     )
 
     # For variation a number of tensor random sizes are used, then tiled with random tile sizes

--- a/opencl/samples/python/TTL_simplex_buffering.cl
+++ b/opencl/samples/python/TTL_simplex_buffering.cl
@@ -1,5 +1,5 @@
 /*
-* ttl_double_buffering.cl
+* ttl_simplex_buffering.cl
 *
 * Copyright (c) 2023 Mobileye
 *
@@ -21,13 +21,12 @@
 
 #define MEMSZ 0x8000
 
-__kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int external_stride_in,
-                                   __global uchar *restrict ext_base_out, int external_stride_out, int width,
-                                   int height, int tile_width, int tile_height) {
-    local uchar l_in1[MEMSZ];
-    local uchar l_in2[MEMSZ];
-    local uchar l_out1[MEMSZ];
-    local uchar l_out2[MEMSZ];
+__kernel void TTL_simplex_buffering(__global uchar *restrict ext_base_in, int external_stride_in,
+                                    __global uchar *restrict ext_base_out, int external_stride_out, int width,
+                                    int height, int tile_width, int tile_height) {
+    __local uchar l_buff1[MEMSZ];
+    __local uchar l_buff2[MEMSZ];
+    __local uchar l_buff3[MEMSZ];
 
     // Logical input tiling.
     const TTL_shape_t tensor_shape_in = TTL_create_shape(width, height);
@@ -48,31 +47,28 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
     const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
     const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
 
-    const TTL_const_ext_tensor_t ext_input_tensor = TTL_create_const_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
+    const TTL_ext_tensor_t ext_input_tensor = TTL_create_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
     const TTL_ext_tensor_t ext_output_tensor = TTL_create_ext_tensor(ext_base_out, tensor_shape_out, ext_layout_out);
 
-    // import_db and export_db need to be defined outside, before the loop, as
-    // they record the event to wait on
-    TTL_event_t import_DB_e = TTL_get_event();
-    TTL_import_double_buffering_t import_db = TTL_start_import_double_buffering(
-        l_in1, l_in2, ext_input_tensor, &import_DB_e, TTL_get_tile(0, input_tiler));
-
-    TTL_event_t export_DB_e = TTL_get_event();
-    TTL_export_double_buffering_t export_db =
-        TTL_start_export_double_buffering(l_out1, l_out2, ext_output_tensor, &export_DB_e);
+    TTL_event_t tb_e_in = TTL_get_event();
+    TTL_event_t tb_e_out = TTL_get_event();
+    TTL_simplex_buffering_t simplex_scheme = TTL_start_simplex_buffering(l_buff1,
+                                                                    l_buff2,
+                                                                    l_buff3,
+                                                                    ext_input_tensor,
+                                                                    ext_output_tensor,
+                                                                    &tb_e_in,
+                                                                    &tb_e_out,
+                                                                    TTL_get_tile(0, input_tiler));
 
     for (int i = 0; i < TTL_number_of_tiles(input_tiler); ++i) {
-        TTL_tile_t t_next = TTL_get_tile(i + 1, input_tiler);
-        // Wait for import #i and issue import #i+1
-        TTL_int_sub_tensor_t imported_to = TTL_step_buffering(&import_db, t_next);
+        TTL_tile_t tile_next_import = TTL_get_tile(i + 1, input_tiler);
+        TTL_tile_t tile_current_export = TTL_get_tile(i, output_tiler);
 
-        TTL_tile_t t_curr = TTL_get_tile(i, output_tiler);
-        // Wait for export #i-2 and issue export #i-1
-        TTL_int_sub_tensor_t exported_from = TTL_step_buffering(&export_db, t_curr);
+        TTL_io_tensors_t tensors = TTL_step_buffering(&simplex_scheme, tile_next_import, tile_current_export);
 
-        compute(imported_to, exported_from);
+        compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&simplex_scheme);
 }

--- a/opencl/samples/python/compute_cross.h
+++ b/opencl/samples/python/compute_cross.h
@@ -1,0 +1,50 @@
+/*
+ * compute_cross.h
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "TTL/TTL.h"
+
+#define TILE_OVERLAP_LEFT 1
+#define TILE_OVERLAP_RIGHT 1
+#define TILE_OVERLAP_TOP 1
+#define TILE_OVERLAP_BOTTOM 1
+
+void compute(TTL_int_sub_tensor_t tensor_in, TTL_int_sub_tensor_t tensor_out) {
+    __local const unsigned char* const restrict l_in = tensor_in.tensor.base;
+    __local unsigned char* const restrict l_out = tensor_out.tensor.base;
+
+    const int x_shift = tensor_out.origin.sub_offset.x - tensor_in.origin.sub_offset.x;
+    const int y_shift = tensor_out.origin.sub_offset.y - tensor_in.origin.sub_offset.y;
+    const int width = tensor_out.tensor.shape.width;
+    const int height = tensor_out.tensor.shape.height;
+    const int stride_in = tensor_in.tensor.layout.row_spacing;
+    const int stride_out = tensor_out.tensor.layout.row_spacing;
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            const int x_in = x + x_shift;
+            const int y_in = y + y_shift;
+            const int left = (y_in * stride_in) + (x_in - 1);
+            const int above = ((y_in - 1) * stride_in) + x_in;
+            const int centre = (y_in * stride_in) + x_in;
+            const int right = (y_in * stride_in) + (x_in + 1);
+            const int bottom = ((y_in + 1) * stride_in) + x_in;
+
+            l_out[y * stride_out + (x)] = l_in[left] + l_in[above] + l_in[centre] + l_in[right] + l_in[bottom];
+        }
+    }
+}

--- a/opencl/test/test_ttl.cpp
+++ b/opencl/test/test_ttl.cpp
@@ -129,8 +129,8 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
         compute(imported_to, exported_from);
     }
 
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
 }
 )";
 
@@ -196,7 +196,7 @@ __kernel void TTL_simplex_buffering(__global uchar *restrict ext_base_in, int ex
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_simplex_buffering(&simplex_scheme);
+    TTL_finish_buffering(&simplex_scheme);
 }
 )";
 
@@ -256,7 +256,7 @@ __kernel void TTL_duplex_buffering(__global uchar *restrict ext_base_in, int ext
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_duplex_buffering(&duplex_scheme);
+    TTL_finish_buffering(&duplex_scheme);
 }
 )";
 // clang-format on

--- a/pipelines/TTL_double_scheme.h
+++ b/pipelines/TTL_double_scheme.h
@@ -109,13 +109,13 @@ static inline TTL_int_sub_tensor_t __TTL_TRACE_FN(TTL_step_buffering, TTL_export
     return result;
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_import_double_buffering,
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering,
                                   TTL_import_double_buffering_t *import_double_buffering) {
     (void)import_double_buffering;
     // Nothing to do.
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_export_double_buffering,
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering,
                                   TTL_export_double_buffering_t *export_double_buffering) {
     TTL_step_buffering(export_double_buffering, TTL_create_empty_tile() __TTL_TRACE_LINE);
     TTL_step_buffering(export_double_buffering, TTL_create_empty_tile() __TTL_TRACE_LINE);

--- a/pipelines/TTL_duplex_scheme.h
+++ b/pipelines/TTL_duplex_scheme.h
@@ -237,6 +237,6 @@ static inline TTL_io_tensors_t __attribute__((overloadable)) __TTL_TRACE_FN(TTL_
     return TTL_create_io_tensors(next_import_int_sub_tensor, to_export_from);
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_duplex_buffering, TTL_duplex_buffering_t *duplex_buffering) {
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering, TTL_duplex_buffering_t *duplex_buffering) {
     TTL_step_buffering(duplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
 }

--- a/pipelines/TTL_simplex_scheme.h
+++ b/pipelines/TTL_simplex_scheme.h
@@ -213,7 +213,7 @@ static inline TTL_io_tensors_t __attribute__((overloadable)) __TTL_TRACE_FN(TTL_
     return TTL_create_io_tensors(int_curr_buff_in, int_curr_buff_out);
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_simplex_buffering, TTL_simplex_buffering_t *simplex_buffering) {
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering, TTL_simplex_buffering_t *simplex_buffering) {
     TTL_step_buffering(simplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
     TTL_step_buffering(simplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
 }


### PR DESCRIPTION
TTL_fetch_tensor allows a tensor to be passed easily from the host to the device. The host sends a ptr to the tensor structure using standard opencl methods.

The Kernel then modes the tensor to __local memory using the TTL_fetch_tensor method.

Examples showing using of this are in opencl/samples/cpp

A minor change included is to rename all the pipeline scheme finish functions TTL_finish_buffering. This provides greater consistancy