### PR TITLE
Rationalize finish_{TYPE}_buffering to be finish_buffering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
     }
 
     // These wait for the last transfers to complete.
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
 }
 ```
 

--- a/TTL_trace_macros.h
+++ b/TTL_trace_macros.h
@@ -31,6 +31,7 @@
 
 #define TTL_import(...) TTL_import(__VA_ARGS__, __LINE__)
 #define TTL_blocking_import(...) TTL_blocking_import(__VA_ARGS__, __LINE__)
+<<<<<<< HEAD
 
 #define TTL_export(...) TTL_export(__VA_ARGS__, __LINE__)
 #define TTL_blocking_export(...) TTL_blocking_export(__VA_ARGS__, __LINE__)
@@ -43,9 +44,16 @@
 #define TTL_start_import_double_buffering(...) TTL_start_import_double_buffering(__VA_ARGS__, __LINE__)
 #define TTL_finish_import_double_buffering(...) TTL_finish_import_double_buffering(__VA_ARGS__, __LINE__)
 
-#define TTL_start_export_double_buffering(...) TTL_start_export_double_buffering(__VA_ARGS__, __LINE__)
-#define TTL_finish_export_double_buffering(...) TTL_finish_export_double_buffering(__VA_ARGS__, __LINE__)
+=======
+#define TTL_blocking_export(...) TTL_blocking_export(__VA_ARGS__, __LINE__)
 
+#define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
+#define TTL_finish_buffering(...) TTL_finish_buffering(__VA_ARGS__, __LINE__)
+
+#define TTL_start_simplex_buffering(...) TTL_start_simplex_buffering(__VA_ARGS__, __LINE__)
+#define TTL_start_import_double_buffering(...) TTL_start_import_double_buffering(__VA_ARGS__)
+>>>>>>> ddd73c2... Rationalize finish_{TYPE}_buffering to be finish_buffering.
+#define TTL_start_export_double_buffering(...) TTL_start_export_double_buffering(__VA_ARGS__, __LINE__)
 #define TTL_start_duplex_buffering(...) TTL_start_duplex_buffering(__VA_ARGS__, __LINE__)
-#define TTL_finish_duplex_buffering(...) TTL_finish_duplex_buffering(__VA_ARGS__, __LINE__)
+
 #endif

--- a/c/samples/TTL_double_buffering.c
+++ b/c/samples/TTL_double_buffering.c
@@ -73,8 +73,8 @@ void TTL_double_buffering(unsigned char *restrict ext_base_in, int external_stri
         compute(imported_to, exported_from);
     }
 
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
 
     result_check(ext_base_in, ext_base_out, width, height, tile_width, tile_height);
 }

--- a/c/samples/TTL_duplex_buffering.c
+++ b/c/samples/TTL_duplex_buffering.c
@@ -69,5 +69,7 @@ void TTL_duplex_buffering(unsigned char *restrict ext_base_in, int external_stri
     }
 
     // This waits for the last transfers to complete.
-    TTL_finish_duplex_buffering(&duplex_scheme);
+    TTL_finish_buffering(&duplex_scheme);
+
+    result_check(ext_base_in, ext_base_out, width, height, tile_width, tile_height);
 }

--- a/c/samples/TTL_simplex_buffering.c
+++ b/c/samples/TTL_simplex_buffering.c
@@ -71,7 +71,7 @@ void TTL_simplex_buffering(unsigned char *restrict ext_base_in, int external_str
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_simplex_buffering(&simplex_scheme);
+    TTL_finish_buffering(&simplex_scheme);
 
     result_check(ext_base_in, ext_base_out, width, height, tile_width, tile_height);
 }

--- a/c/samples/compute_cross.h
+++ b/c/samples/compute_cross.h
@@ -53,6 +53,7 @@ void result_check(unsigned char* const ext_base_in, unsigned char* const ext_bas
                   const int height, const int tile_width, const int tile_height) {
     uint8_t(*const input_buffer)[height][width] = (uint8_t(*)[height][width])ext_base_in;
     uint8_t(*const output_buffer)[height][width] = (uint8_t(*)[height][width])ext_base_out;
+    bool result = true;
 
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
@@ -76,7 +77,12 @@ void result_check(unsigned char* const ext_base_in, unsigned char* const ext_bas
                        height,
                        tile_width,
                        tile_height);
+                result = false;
             }
         }
+    }
+
+    if (result == true) {
+        printf("Compute checked and successful\n");
     }
 }

--- a/opencl/samples/TTL_double_buffering.cl
+++ b/opencl/samples/TTL_double_buffering.cl
@@ -73,6 +73,6 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
         compute(imported_to, exported_from);
     }
 
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
 }

--- a/opencl/samples/TTL_duplex_buffering.cl
+++ b/opencl/samples/TTL_duplex_buffering.cl
@@ -66,7 +66,5 @@ __kernel void TTL_duplex_buffering(__global uchar *restrict ext_base_in, int ext
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    // This waits for the last transfers to complete.
-    TTL_finish_duplex_buffering(&duplex_scheme);
-
+    TTL_finish_buffering(&duplex_scheme);
 }

--- a/opencl/samples/TTL_simplex_buffering.cl
+++ b/opencl/samples/TTL_simplex_buffering.cl
@@ -70,5 +70,5 @@ __kernel void TTL_simplex_buffering(__global uchar *restrict ext_base_in, int ex
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_simplex_buffering(&simplex_scheme);
+    TTL_finish_buffering(&simplex_scheme);
 }

--- a/opencl/test/test_ttl.cpp
+++ b/opencl/test/test_ttl.cpp
@@ -129,8 +129,8 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
         compute(imported_to, exported_from);
     }
 
-    TTL_finish_import_double_buffering(&import_db);
-    TTL_finish_export_double_buffering(&export_db);
+    TTL_finish_buffering(&import_db);
+    TTL_finish_buffering(&export_db);
 }
 )";
 
@@ -196,7 +196,7 @@ __kernel void TTL_simplex_buffering(__global uchar *restrict ext_base_in, int ex
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_simplex_buffering(&simplex_scheme);
+    TTL_finish_buffering(&simplex_scheme);
 }
 )";
 
@@ -256,7 +256,7 @@ __kernel void TTL_duplex_buffering(__global uchar *restrict ext_base_in, int ext
         compute(tensors.imported_to, tensors.to_export_from);
     }
 
-    TTL_finish_duplex_buffering(&duplex_scheme);
+    TTL_finish_buffering(&duplex_scheme);
 }
 )";
 // clang-format on

--- a/pipelines/TTL_double_scheme.h
+++ b/pipelines/TTL_double_scheme.h
@@ -109,13 +109,13 @@ static inline TTL_int_sub_tensor_t __attribute__((overloadable)) __TTL_TRACE_FN(
     return result;
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_import_double_buffering,
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering,
                                   TTL_import_double_buffering_t *import_double_buffering) {
     (void)import_double_buffering;
     // Nothing to do.
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_export_double_buffering,
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering,
                                   TTL_export_double_buffering_t *export_double_buffering) {
     TTL_step_buffering(export_double_buffering, TTL_create_empty_tile() __TTL_TRACE_LINE);
     TTL_step_buffering(export_double_buffering, TTL_create_empty_tile() __TTL_TRACE_LINE);

--- a/pipelines/TTL_duplex_scheme.h
+++ b/pipelines/TTL_duplex_scheme.h
@@ -237,6 +237,6 @@ static inline TTL_io_tensors_t __attribute__((overloadable)) __TTL_TRACE_FN(TTL_
     return TTL_create_io_tensors(next_import_int_sub_tensor, to_export_from);
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_duplex_buffering, TTL_duplex_buffering_t *duplex_buffering) {
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering, TTL_duplex_buffering_t *duplex_buffering) {
     TTL_step_buffering(duplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
 }

--- a/pipelines/TTL_simplex_scheme.h
+++ b/pipelines/TTL_simplex_scheme.h
@@ -213,7 +213,7 @@ static inline TTL_io_tensors_t __attribute__((overloadable)) __TTL_TRACE_FN(TTL_
     return TTL_create_io_tensors(int_curr_buff_in, int_curr_buff_out);
 }
 
-static inline void __TTL_TRACE_FN(TTL_finish_simplex_buffering, TTL_simplex_buffering_t *simplex_buffering) {
+static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_finish_buffering, TTL_simplex_buffering_t *simplex_buffering) {
     TTL_step_buffering(simplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
     TTL_step_buffering(simplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
 }


### PR DESCRIPTION
Because Finish_Buffering taks a single strong typed structure the function name can simply be finish_buffering where the passed parameter is used to select the correct implementation.

Changes are

TTL_finish_import_double_buffering
TTL_finish_exort_double_buffering
TTL_finish_simplex_buffering
TTL_finish_duplex_buffering

Some duplicates in the debug macros are also removed.