### PR TITLE
Add github actions to build and Deploy Doxygen Pages

### DIFF
--- a/.github/workflows/build-and-deploy-doxygen.yml
+++ b/.github/workflows/build-and-deploy-doxygen.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Build and Deploy Doxygen
+run-name: ${{ github.actor }} is building and deploying Doxygen
+on: [push]
+jobs:
+  build-and-deploy-doxygen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Info
+        run: |
+          echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+          echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+          echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - run: echo "💡 Building Doxygen."
+      - name: Build Doxygen
+        uses: mattnotmitt/doxygen-action@v1.9.4
+        with:
+            working-directory: .
+            doxyfile-path: scripts/doxyfile.in
+
+      - if: github.ref == 'refs/heads/main'
+        name: Deploy Doxygen
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: gh-pages
+          single-commit: true
+
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This document outlines the purpose of this sample implementation and provides bu
 - [Tensor Tiling Library](#tensor-tiling-library)
   - [Purpose](#purpose)
   - [Example](#example)
+  - [Doxygen](#doxygen)
   - [Building And Executing](#building-and-executing)
     - [CMake](#cmake)
       - [Tested Supported Systems](#tested-supported-systems)
@@ -98,6 +99,11 @@ __kernel void TTL_double_buffering(__global uchar *restrict ext_base_in, int ext
     TTL_finish_export_double_buffering(&export_db);
 }
 ```
+
+## Doxygen
+
+Doxygen is supported and can be build using the scripts/generate_doxygen.sh script. It is
+built automatically by github for main and the latest version can be found at https://github.khronos.org/OpenCL-TTL/
 
 ## Building And Executing
 

--- a/gh-pages/index.html
+++ b/gh-pages/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1;url=html/index.html">
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        If you are not redirected automatically, follow the <a href="html/index.html">link to the documentation</a>
+    </body>
+</html>

--- a/scripts/doxyfile.in
+++ b/scripts/doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           = doc/tensor_tiling_library_slim.png
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = 
+OUTPUT_DIRECTORY       = gh-pages
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and


### PR DESCRIPTION
Add a github action to build and deploy doxygen plages to the gh-pages branch.

See online help for details of the build-and_deploy_doxygen.yml file contents. The README.md has been changed to provide a link to the online help.

This solution means only the tip of main is documented online, which is a standard approach.