### PR TITLE
Resolve compilation error when using TTL debug definition

### DIFF
--- a/TTL_macros.h
+++ b/TTL_macros.h
@@ -75,7 +75,7 @@
  * @def __TTL_TRACE_FN
  *
  * A function defined using __TTL_TRACE_FN will have an additional "unsigned int line" parameter
- * added is __TTL_DEBUG > 0.  This line parameter allows for the output of the line of code originating
+ * added if __TTL_DEBUG > 0.  This line parameter allows for the output of the line of code originating
  * the call.
  *
  * For example:

--- a/TTL_trace_macros.h
+++ b/TTL_trace_macros.h
@@ -28,22 +28,19 @@
 #if __TTL_DEBUG > 0
 
 #define TTL_import_sub_tensor(...) TTL_import_sub_tensor(__VA_ARGS__, __LINE__)
+
 #define TTL_import(...) TTL_import(__VA_ARGS__, __LINE__)
 #define TTL_blocking_import(...) TTL_blocking_import(__VA_ARGS__, __LINE__)
-#define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
 
+#define TTL_export(...) TTL_export(__VA_ARGS__, __LINE__)
 #define TTL_blocking_export(...) TTL_blocking_export(__VA_ARGS__, __LINE__)
-#define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
 
-#define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
 #define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
 
 #define TTL_start_simplex_buffering(...) TTL_start_simplex_buffering(__VA_ARGS__, __LINE__)
 #define TTL_finish_simplex_buffering(...) TTL_finish_simplex_buffering(__VA_ARGS__, __LINE__)
 
-#define TTL_step_buffering(...) TTL_step_buffering(__VA_ARGS__, __LINE__)
-
-#define TTL_start_import_double_buffering(...) TTL_start_import_double_buffering(__VA_ARGS__)
+#define TTL_start_import_double_buffering(...) TTL_start_import_double_buffering(__VA_ARGS__, __LINE__)
 #define TTL_finish_import_double_buffering(...) TTL_finish_import_double_buffering(__VA_ARGS__, __LINE__)
 
 #define TTL_start_export_double_buffering(...) TTL_start_export_double_buffering(__VA_ARGS__, __LINE__)

--- a/c/samples/README.md
+++ b/c/samples/README.md
@@ -12,15 +12,25 @@ Install the TTL include files as described in [INSTALL](../../INSTALL)
 
 ## Python Wrapper
 
+    export TTL_INCLUDE_PATH=[PATH TO TTL]
+    export TTL_EXTRA_DEFINES=[ANY EXTRA DEFINES]
     ./TTL_sample_runner.py TTL_double_buffering.c
 
 The name can be wildcarded
 
+    export TTL_INCLUDE_PATH=[PATH TO TTL]
+    export TTL_EXTRA_DEFINES=[ANY EXTRA DEFINES]
     ./TTL_sample_runner.py TTL_*.c
+
+TTL_EXTRA_DEFINES can for example define __TTL_DEBUG=1 to provide additional
+debug output. 
+
+    export TTL_EXTRA_DEFINES="__TTL_DEBUG=1"
 
 ## C Wrapper
 
-    clang -Wextra -Wall -DKERNEL_NAME=TTL_duplex_buffering -DTTL_TARGET=c -g -O0 main.c TTL_duplex_buffering.c -o c_test
+    export TTL_INCLUDE_PATH=[PATH TO TTL]
+    clang -Wextra -Wall -DKERNEL_NAME=TTL_duplex_buffering -I $TTL_INCLUDE_PATH -DTTL_TARGET=c -g -O0 main.c TTL_duplex_buffering.c -o c_test
     ./c_test
 
 ## The "Kernel"

--- a/c/samples/TTL_sample_runner.py
+++ b/c/samples/TTL_sample_runner.py
@@ -36,6 +36,12 @@ def TestTTL(program_name):
     else:
         ttl_include_path = ""
 
+    # Allow an environment variable to provide the TTL_INCLUDE_PATH, if not defined regular paths used.
+    if "TTL_EXTRA_DEFINES" in os.environ:
+        ttl_extra_defines =  " " + os.environ["TTL_EXTRA_DEFINES"] + " "
+    else:
+        ttl_extra_defines = ""
+
     # For convenience remove any extension if it included.
     program_name = os.path.splitext(os.path.basename(program_name))[0]
 
@@ -46,6 +52,7 @@ def TestTTL(program_name):
         + ttl_include_path
         + " -DKERNEL_NAME="
         + program_name
+        + ttl_extra_defines
         + " -DTTL_TARGET=c -fPIC -shared -o "
         + program_name
         + ".so "

--- a/opencl/TTL_import_export.h
+++ b/opencl/TTL_import_export.h
@@ -80,7 +80,7 @@ static inline void __TTL_TRACE_FN(TTL_import, const TTL_int_tensor_t internal_te
 
 #if __TTL_DEBUG > 0
     __TTL_dump_transaction(
-        false, TTL_int_tensor_to_const_int_tensor(&internal_tensor), &external_tensor, 0, event __TTL_TRACE_LINE);
+        false, TTL_to_const_tensor(&internal_tensor), &external_tensor, 0, event __TTL_TRACE_LINE);
 #endif  // __TTL_DEBUG
 }
 
@@ -130,7 +130,7 @@ static inline void __TTL_TRACE_FN(TTL_export, const TTL_const_int_tensor_t inter
 
 #if __TTL_DEBUG > 0
     __TTL_dump_transaction(
-        true, &internal_tensor, TTL_ext_tensor_to_const_ext_tensor(&external_tensor), 0, event __TTL_TRACE_LINE);
+        true, &internal_tensor, TTL_to_const_tensor(&external_tensor), 0, event __TTL_TRACE_LINE);
 #endif  // __TTL_DEBUG
 }
 

--- a/opencl/samples/README.md
+++ b/opencl/samples/README.md
@@ -13,11 +13,20 @@ Install an OpenCL environment such a POCL. The tests were carried out with POCL.
 
 ## Python Wrapper
 
-    ./TTL_sample_runner.py TTL_double_buffering.cl
+    export TTL_INCLUDE_PATH=[PATH TO TTL]
+    export TTL_EXTRA_DEFINES=[ANY EXTRA DEFINES]
+   ./TTL_sample_runner.py TTL_double_buffering.cl
 
 The name can be wildcarded
 
+    export TTL_INCLUDE_PATH=[PATH TO TTL]
+    export TTL_EXTRA_DEFINES=[ANY EXTRA DEFINES]
     ./TTL_sample_runner.py TTL_*.cl
+
+TTL_EXTRA_DEFINES can for example define __TTL_DEBUG=1 to provide additional
+debug output. 
+
+    export TTL_EXTRA_DEFINES="__TTL_DEBUG=1"
 
 ## The "Kernel"
 

--- a/opencl/samples/TTL_sample_runner.py
+++ b/opencl/samples/TTL_sample_runner.py
@@ -34,13 +34,23 @@ def TestTTL(program_name):
     else:
         ttl_include_path = "-I /usr/local/include/"
 
+    # Allow an environment variable to provide the TTL_INCLUDE_PATH, if not defined regular paths used.
+    if "TTL_EXTRA_DEFINES" in os.environ:
+        ttl_extra_defines =  " " + os.environ["TTL_EXTRA_DEFINES"] + " "
+    else:
+        ttl_extra_defines = ""
+
     context = cl.create_some_context()
     queue = cl.CommandQueue(context)
 
     # For convenience remove the .cl extension if it included.
     program_name = os.path.splitext(program_name)[0]
     program = cl.Program(context, open(program_name + ".cl").read()).build(
+<<<<<<< HEAD
         options=ttl_include_path + " -DTTL_COPY_3D"
+=======
+        options=ttl_include_path + ttl_extra_defines + " -DTTL_COPY_3D"
+>>>>>>> 13a3b65... Resolve compilation error when using TTL debug definition
     )
 
     # For variation a number of tensor random sizes are used, then tiled with random tile sizes

--- a/pipelines/TTL_double_scheme_template.h
+++ b/pipelines/TTL_double_scheme_template.h
@@ -113,11 +113,11 @@ typedef struct {
  *
  * @enduml
  */
-static inline TTL_double_buffering_internal_t TTL_start_import_double_buffering(TTL_local(TTL_int_ptr) int_base1,
-                                                                                TTL_local(TTL_int_ptr) int_base2,
-                                                                                TTL_ext_tensor_type ext_tensor,
-                                                                                TTL_event_t *event,
-                                                                                TTL_tile_t first_tile);
+static inline TTL_double_buffering_internal_t __TTL_TRACE_FN(TTL_start_import_double_buffering,
+                                                             TTL_local(TTL_int_ptr) int_base1,
+                                                             TTL_local(TTL_int_ptr) int_base2,
+                                                             TTL_ext_tensor_type ext_tensor, TTL_event_t *event,
+                                                             TTL_tile_t first_tile);
 #endif
 
 #ifdef TTL_EXPORT_DOUBLE
@@ -154,14 +154,14 @@ static inline TTL_double_buffering_internal_t TTL_start_import_double_buffering(
  *
  * @enduml
  */
-static inline TTL_double_buffering_internal_t TTL_start_export_double_buffering(TTL_local(TTL_int_ptr) int_base1,
-                                                                                TTL_local(TTL_int_ptr) int_base2,
-                                                                                TTL_ext_tensor_type ext_tensor,
-                                                                                TTL_event_t *event);
+static inline TTL_double_buffering_internal_t __TTL_TRACE_FN(TTL_start_export_double_buffering,
+                                                             TTL_local(TTL_int_ptr) int_base1,
+                                                             TTL_local(TTL_int_ptr) int_base2,
+                                                             TTL_ext_tensor_type ext_tensor, TTL_event_t *event);
 #endif
 
-static inline TTL_int_sub_tensor_t __attribute__((overloadable))__TTL_TRACE_FN(TTL_step_buffering, TTL_import_double_buffering_t *const dbi,
-                                                  const TTL_tile_t next_tile);
+static inline TTL_int_sub_tensor_t __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_step_buffering, TTL_import_double_buffering_t *const dbi, const TTL_tile_t next_tile);
 
 static inline TTL_double_buffering_internal_t __TTL_TRACE_FN(TTL_name(TTL_start, double_buffering),
                                                              TTL_local(TTL_int_ptr) int_base1,

--- a/pipelines/TTL_simplex_scheme.h
+++ b/pipelines/TTL_simplex_scheme.h
@@ -118,7 +118,7 @@ static inline TTL_io_tensors_t __attribute__((overloadable)) __TTL_TRACE_FN(TTL_
  * @enduml
  *
  */
-static inline TTL_simplex_buffering_t TTL_start_simplex_buffering(
+static inline TTL_simplex_buffering_t __TTL_TRACE_FN(TTL_start_simplex_buffering,
     TTL_local(void *) int_base1, TTL_local(void *) int_base2, TTL_local(void *) int_base3,
     TTL_ext_tensor_t ext_tensor_in, TTL_ext_tensor_t ext_tensor_out, TTL_event_t *event_in, TTL_event_t *event_out,
     TTL_tile_t first_tile) {


### PR DESCRIPTION
The __TTL_DEBUG macro was causing compile errors due to a misdefinition of TTL_start_import_double_buffering and some usages of old TTL_int_tensor_to_const_int_tensor rather than the overloaded TTL_to_const_tensor

This patch resolves these and added a method for defining arbitary defines in the samples through the use of TTL_EXTRA_DEFINES. The documentation is updated.