### PR TITLE
Demonstrate passing a Tensor from Host to Kernel

### DIFF
--- a/opencl/samples/cpp/TTL_sample_overlap.cl
+++ b/opencl/samples/cpp/TTL_sample_overlap.cl
@@ -27,14 +27,9 @@
 #define TILE_WIDTH 10
 #define TILE_HEIGHT 10
 
-__kernel void TTL_sample_overlap(__global uchar* const restrict ext_base_in, const TTL_shape_t shape_in,
-                                 const TTL_layout_t layout_in, __global uchar* const restrict ext_base_out,
-                                 const TTL_shape_t shape_out, const TTL_layout_t layout_out) {
-    __local TTL_ext_tensor_t ext_input_tensor, ext_output_tensor;
+__kernel void TTL_sample_overlap(__global void *unused_ptr_1, const TTL_ext_tensor_t ext_input_tensor,
+                                 const TTL_ext_tensor_t ext_output_tensor) {
     __local uchar l_in[TILE_SIZE], l_out[TILE_SIZE];
-
-    ext_input_tensor = TTL_create_ext_tensor(ext_base_in, shape_in, layout_in);
-    ext_output_tensor = TTL_create_ext_tensor(ext_base_out, shape_out, layout_out);
 
     // Logical input tiling.
     const TTL_shape_t tile_shape_in = TTL_create_shape(TILE_WIDTH + (TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT),


### PR DESCRIPTION
Update the c and CPP samples to pass the Tensor from the Host to the Kernel.  This demonstrates TTL structures and methods being used on the Host and the Device side.

Passing of structures with pointers is only support in OpenCL 3.0 and only implemented in clang 17, for this reason a bug in clang is used to allow the passing of a pointer.

For speed that validaty of a parameter passed to the Kernel is cached. If a pointer is passed outside of a struct and then in a struct the validaty of the pointer within the struct is not checked but cached as OK.  The current code makes use of the bug to allow the demonstration. With Clang 17 this workaround would not be required.