### PR TITLE
Add TTL_read_tensor and TTL_write_tensor

### DIFF
--- a/TTL_create_type.h
+++ b/TTL_create_type.h
@@ -17,5 +17,5 @@
  */
 
 // Simplly designed to prevent multiple #undef TTL_TENSOR_TYPE
-#include TYPES_INCLUDE_FILE
+#include TTL_TYPES_INCLUDE_FILE
 #undef TTL_TENSOR_TYPE

--- a/TTL_create_types.h
+++ b/TTL_create_types.h
@@ -22,9 +22,12 @@
 
 #pragma push_macro("TTL_TENSOR_TYPE")
 
+#ifndef TTL_TYPES_NO_VOID
 #define TTL_TENSOR_TYPE void
 #define sizeof_void sizeof(char)
 #include "TTL_create_type.h"
+#endif
+#undef TTL_TYPES_NO_VOID
 
 #define TTL_TENSOR_TYPE char
 #define sizeof_char sizeof(char)
@@ -58,6 +61,6 @@
 #define sizeof_ulong sizeof(ulong)
 #include "TTL_create_type.h"
 
-#undef TYPES_INCLUDE_FILE
+#undef TTL_TYPES_INCLUDE_FILE
 
 #pragma pop_macro("TTL_TENSOR_TYPE")

--- a/TTL_import_export.h
+++ b/TTL_import_export.h
@@ -136,5 +136,5 @@ static inline TTL_shape_t TTL_import_pre_fill(const TTL_int_sub_tensor_t interna
 }
 
 
-#define TYPES_INCLUDE_FILE "import_export/TTL_typed_import_export.h"
+#define TTL_TYPES_INCLUDE_FILE "import_export/TTL_typed_import_export.h"
 #include "TTL_create_types.h"

--- a/TTL_pipeline_schemes.h
+++ b/TTL_pipeline_schemes.h
@@ -22,11 +22,11 @@
 #include "TTL_import_export.h"
 #include TTL_IMPORT_EXPORT_INCLUDE_H
 
-#define TYPES_INCLUDE_FILE "pipelines/TTL_double_scheme.h"
+#define TTL_TYPES_INCLUDE_FILE "pipelines/TTL_double_scheme.h"
 #include "TTL_create_types.h"
 
-#define TYPES_INCLUDE_FILE "pipelines/TTL_simplex_scheme.h"
+#define TTL_TYPES_INCLUDE_FILE "pipelines/TTL_simplex_scheme.h"
 #include "TTL_create_types.h"
 
-#define TYPES_INCLUDE_FILE "pipelines/TTL_duplex_scheme.h"
+#define TTL_TYPES_INCLUDE_FILE "pipelines/TTL_duplex_scheme.h"
 #include "TTL_create_types.h"

--- a/TTL_tensors.h
+++ b/TTL_tensors.h
@@ -21,3 +21,8 @@
 #include "tensors/TTL_tensors_common.h"
 #include "tensors/TTL_ext_tensors.h"
 #include "tensors/TTL_int_tensors.h"
+
+
+#define TTL_TYPES_INCLUDE_FILE "tensors/TTL_tensor_rw.h"
+#define TTL_TYPES_NO_VOID
+#include "TTL_create_types.h"

--- a/c/samples/compute_cross.h
+++ b/c/samples/compute_cross.h
@@ -25,30 +25,20 @@
 
 void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
              __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
-    const TEST_TENSOR_TYPE* const restrict l_in = tensor_in.tensor.base;
-    TEST_TENSOR_TYPE* const restrict l_out = tensor_out.tensor.base;
-
-    const int x_shift = tensor_out.origin.sub_offset.x - tensor_in.origin.sub_offset.x;
-    const int y_shift = tensor_out.origin.sub_offset.y - tensor_in.origin.sub_offset.y;
-    const int width = tensor_out.tensor.shape.width;
-    const int height = tensor_out.tensor.shape.height;
-    const int stride_in = tensor_in.tensor.layout.row_spacing;
-    const int stride_out = tensor_out.tensor.layout.row_spacing;
-
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            const int x_in = x + x_shift;
-            const int y_in = y + y_shift;
-            const int left = (y_in * stride_in) + (x_in - 1);
-            const int above = ((y_in - 1) * stride_in) + x_in;
-            const int centre = (y_in * stride_in) + x_in;
-            const int right = (y_in * stride_in) + (x_in + 1);
-            const int bottom = ((y_in + 1) * stride_in) + x_in;
+    for (int y = 0; y < tensor_out.tensor.shape.height; ++y) {
+        for (int x = 0; x < tensor_out.tensor.shape.width; ++x) {
+            const int x_in = x + TILE_OVERLAP_LEFT;
+            const int y_in = y + TILE_OVERLAP_TOP;
+            const TEST_TENSOR_TYPE left = TTL_read_tensor(tensor_in, x_in - 1, y_in);
+            const TEST_TENSOR_TYPE above = TTL_read_tensor(tensor_in, x_in, y_in - 1);
+            const TEST_TENSOR_TYPE centre = TTL_read_tensor(tensor_in, x_in, y_in);
+            const TEST_TENSOR_TYPE right = TTL_read_tensor(tensor_in, x_in + 1, y_in);
+            const TEST_TENSOR_TYPE bottom = TTL_read_tensor(tensor_in, x_in, y_in + 1);
 
             if (true)
-                l_out[y * stride_out + (x)] = l_in[left] + l_in[above] + l_in[centre] + l_in[right] + l_in[bottom];
+                TTL_write_tensor(tensor_out, left + above + centre + right + bottom, x, y);
             else
-                l_out[y * stride_out + (x)] = l_in[centre];
+                TTL_write_tensor(tensor_out, centre, x, y);
         }
     }
 }

--- a/opencl/samples/cpp/README.md
+++ b/opencl/samples/cpp/README.md
@@ -17,18 +17,10 @@ Compile as follows
 ```
 export TTL_INCLUDE_PATH=[PATH TO TTL]
 export OPEN_CL_INCLUDE_PATH=[PATH_TO_OPENCL_INCLUDE_FILES]
-for type in char uchar short ushort int uint long ulong; do
-for compute in cross square copy; do
-
-echo Compute $compute with Tensor of type $type
-clang -O0 -g -D TTL_TARGET=c -D TEST_TENSOR_TYPE=$type -D COMPUTE=$compute.h -D CL_TARGET_OPENCL_VERSION=300 -I $TTL_INCLUDE_PATH -I $OPEN_CL_INCLUDE_PATH -o TTL_sample_overlap TTL_sample_runner.cpp -lOpenCL -lstdc++
-./TTL_sample_overlap
-
-done
-done
+./test_all_types.sh
 ```
 
-## The "Copy Kernel" 
+## The "Copy Kernel"
 
 The kernel simply copies the input buffer to the output buffer
 

--- a/opencl/samples/cpp/compute_copy.h
+++ b/opencl/samples/cpp/compute_copy.h
@@ -23,18 +23,39 @@
 #define TILE_OVERLAP_TOP 0
 #define TILE_OVERLAP_BOTTOM 0
 
-void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
-             __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
-    __local const TEST_TENSOR_TYPE* const l_in = tensor_in.tensor.base;
-    __local TEST_TENSOR_TYPE* const l_out = tensor_out.tensor.base;
-    const int width = tensor_out.tensor.shape.width;
-    const int height = tensor_out.tensor.shape.height;
-    const int stride_in = tensor_in.tensor.layout.row_spacing;
-    const int stride_out = tensor_out.tensor.layout.row_spacing;
+/*
+ * @brief Compute code based on a tensor
+ *
+ * Compute the copy of the input tensor placing the result into the output tensor
+ *
+ * @param tensor_in The input tensor
+ * @param tensor_out The output tensor
+ *
+ * We split compute into compute and compute_copy to demonstrate use of TTL_[read|write]_tensor
+ * with a simple tensor
+ */
+void compute_copy(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, , _t) tensor_in,
+             __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, , _t) tensor_out) {
 
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            l_out[(y * stride_out) + x] = l_in[(y * stride_in) + x];
+    for (int y = 0; y < tensor_in.shape.height; ++y) {
+        for (int x = 0; x < tensor_out.shape.width; ++x) {
+            TTL_write_tensor(tensor_out, TTL_read_tensor(tensor_in, x, y), x, y);
         }
     }
+}
+
+/*
+ * @brief Compute code based on a tensor
+ *
+ * Compute the copy of the input tensor placing the result into the output tensor
+ *
+ * @param tensor_in The input sub tensor
+ * @param tensor_out The output sub tensor
+ *
+ * We split compute into compute and compute_copy to demonstrate use of TTL_[read|write]_tensor
+*/
+
+void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
+             __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
+    compute_copy(tensor_in.tensor, tensor_out.tensor);
 }

--- a/opencl/samples/cpp/compute_cross.h
+++ b/opencl/samples/cpp/compute_cross.h
@@ -25,27 +25,17 @@
 
 void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
              __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
-    __local const TEST_TENSOR_TYPE* const l_in = tensor_in.tensor.base;
-    __local TEST_TENSOR_TYPE* const l_out = tensor_out.tensor.base;
+    for (int y = 0; y < tensor_out.tensor.shape.height; ++y) {
+        for (int x = 0; x < tensor_out.tensor.shape.width; ++x) {
+            const int x_in = x + TILE_OVERLAP_LEFT;
+            const int y_in = y + TILE_OVERLAP_TOP;
+            const TEST_TENSOR_TYPE left = TTL_read_tensor(tensor_in, x_in - 1, y_in);
+            const TEST_TENSOR_TYPE above = TTL_read_tensor(tensor_in, x_in, y_in - 1);
+            const TEST_TENSOR_TYPE centre = TTL_read_tensor(tensor_in, x_in, y_in);
+            const TEST_TENSOR_TYPE right = TTL_read_tensor(tensor_in, x_in + 1, y_in);
+            const TEST_TENSOR_TYPE bottom = TTL_read_tensor(tensor_in, x_in, y_in + 1);
 
-    const int x_shift = tensor_out.origin.sub_offset.x - tensor_in.origin.sub_offset.x;
-    const int y_shift = tensor_out.origin.sub_offset.y - tensor_in.origin.sub_offset.y;
-    const int width = tensor_out.tensor.shape.width;
-    const int height = tensor_out.tensor.shape.height;
-    const int stride_in = tensor_in.tensor.layout.row_spacing;
-    const int stride_out = tensor_out.tensor.layout.row_spacing;
-
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            const int x_in = x + x_shift;
-            const int y_in = y + y_shift;
-            const int left = (y_in * stride_in) + (x_in - 1);
-            const int above = ((y_in - 1) * stride_in) + x_in;
-            const int centre = (y_in * stride_in) + x_in;
-            const int right = (y_in * stride_in) + (x_in + 1);
-            const int bottom = ((y_in + 1) * stride_in) + x_in;
-
-            l_out[y * stride_out + (x)] = l_in[left] + l_in[above] + l_in[centre] + l_in[right] + l_in[bottom];
+            TTL_write_tensor(tensor_out, left + above + centre + right + bottom, x, y);
         }
     }
 }

--- a/opencl/samples/cpp/compute_square.h
+++ b/opencl/samples/cpp/compute_square.h
@@ -23,18 +23,38 @@
 #define TILE_OVERLAP_TOP 0
 #define TILE_OVERLAP_BOTTOM 0
 
-void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
-             __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
-    __local const TEST_TENSOR_TYPE* const l_in = tensor_in.tensor.base;
-    __local TEST_TENSOR_TYPE* const l_out = tensor_out.tensor.base;
-    const int width = tensor_out.tensor.shape.width;
-    const int height = tensor_out.tensor.shape.height;
-    const int stride_in = tensor_in.tensor.layout.row_spacing;
-    const int stride_out = tensor_out.tensor.layout.row_spacing;
+/*
+ * @brief Compute code based on a tensor
+ *
+ * Compute the square of the input tensor placing the result into the output tensor
+ *
+ * @param tensor_in The input tensor
+ * @param tensor_out The output tensor
+ *
+ * We split compute into compute and compute_square to demonstrate use of TTL_[read|write]_tensor
+ * with a simple tensor
+ */
+void compute_square(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, , _t) tensor_in,
+             __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, , _t) tensor_out) {
 
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            l_out[(y * stride_out) + x] = l_in[(y * stride_in) + x] * l_in[(y * stride_in) + x];
+    for (int y = 0; y < tensor_out.shape.height; ++y) {
+        for (int x = 0; x < tensor_out.shape.width; ++x) {
+            TTL_write_tensor(tensor_out, TTL_read_tensor(tensor_in, x, y) * TTL_read_tensor(tensor_in, x, y), x, y);
         }
     }
+}
+
+/*
+ * @brief Compute code based on a tensor
+ *
+ * Compute the square of the input tensor placing the result into the output tensor
+ *
+ * @param tensor_in The input sub tensor
+ * @param tensor_out The output sub tensor
+ *
+ * We split compute into compute and compute_square to demonstrate use of TTL_[read|write]_tensor
+*/
+void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
+             __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
+    compute_square(tensor_in.tensor, tensor_out.tensor);
 }

--- a/opencl/samples/cpp/test_all_types.sh
+++ b/opencl/samples/cpp/test_all_types.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# test_all_types.h
+#
+# Copyright (c) 2023 Mobileye
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+for type in char uchar short ushort int uint long ulong; do
+  for compute in cross square copy; do
+
+    echo Compute $compute with Tensor of type $type
+    clang -O0 -g -D TTL_TARGET=c -D TEST_TENSOR_TYPE=$type -D COMPUTE=$compute.h -D CL_TARGET_OPENCL_VERSION=300 -I $TTL_INCLUDE_PATH -I $OPEN_CL_INCLUDE_PATH -o TTL_sample_overlap TTL_sample_runner.cpp -lOpenCL -lstdc++
+    ./TTL_sample_overlap
+
+  done
+done

--- a/opencl/samples/python/compute_cross.h
+++ b/opencl/samples/python/compute_cross.h
@@ -18,34 +18,24 @@
 
 #include "TTL/TTL.h"
 
-#define TILE_OVERLAP_LEFT 1
-#define TILE_OVERLAP_RIGHT 1
-#define TILE_OVERLAP_TOP 1
-#define TILE_OVERLAP_BOTTOM 1
+#define TILE_OVERLAP_LEFT 10
+#define TILE_OVERLAP_RIGHT 10
+#define TILE_OVERLAP_TOP 10
+#define TILE_OVERLAP_BOTTOM 10
 
 void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
              __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
-    __local const TEST_TENSOR_TYPE* const l_in = tensor_in.tensor.base;
-    __local TEST_TENSOR_TYPE* const l_out = tensor_out.tensor.base;
+    for (int y = 0; y < tensor_out.tensor.shape.height; ++y) {
+        for (int x = 0; x < tensor_out.tensor.shape.width; ++x) {
+            const int x_in = x + TILE_OVERLAP_LEFT;
+            const int y_in = y + TILE_OVERLAP_TOP;
+            const TEST_TENSOR_TYPE left = TTL_read_tensor(tensor_in, x_in - 1, y_in);
+            const TEST_TENSOR_TYPE above = TTL_read_tensor(tensor_in, x_in, y_in - 1);
+            const TEST_TENSOR_TYPE centre = TTL_read_tensor(tensor_in, x_in, y_in);
+            const TEST_TENSOR_TYPE right = TTL_read_tensor(tensor_in, x_in + 1, y_in);
+            const TEST_TENSOR_TYPE bottom = TTL_read_tensor(tensor_in, x_in, y_in + 1);
 
-    const int x_shift = tensor_out.origin.sub_offset.x - tensor_in.origin.sub_offset.x;
-    const int y_shift = tensor_out.origin.sub_offset.y - tensor_in.origin.sub_offset.y;
-    const int width = tensor_out.tensor.shape.width;
-    const int height = tensor_out.tensor.shape.height;
-    const int stride_in = tensor_in.tensor.layout.row_spacing;
-    const int stride_out = tensor_out.tensor.layout.row_spacing;
-
-    for (int y = 0; y < height; ++y) {
-        for (int x = 0; x < width; ++x) {
-            const int x_in = x + x_shift;
-            const int y_in = y + y_shift;
-            const int left = (y_in * stride_in) + (x_in - 1);
-            const int above = ((y_in - 1) * stride_in) + x_in;
-            const int centre = (y_in * stride_in) + x_in;
-            const int right = (y_in * stride_in) + (x_in + 1);
-            const int bottom = ((y_in + 1) * stride_in) + x_in;
-
-            l_out[y * stride_out + (x)] = l_in[left] + l_in[above] + l_in[centre] + l_in[right] + l_in[bottom];
+            TTL_write_tensor(tensor_out, left + above + centre + right + bottom, x, y);
         }
     }
 }

--- a/pipelines/TTL_schemes_common.h
+++ b/pipelines/TTL_schemes_common.h
@@ -20,14 +20,14 @@
 // this is not done here for path reasons.
 // #include "TTL_core.h"
 #ifndef DEFINING_TTL_SCHEMES_COMMON
-#pragma push_macro("TYPES_INCLUDE_FILE")
-#undef TYPES_INCLUDE_FILE
-#define TYPES_INCLUDE_FILE "pipelines/TTL_schemes_common.h"
+#pragma push_macro("TTL_TYPES_INCLUDE_FILE")
+#undef TTL_TYPES_INCLUDE_FILE
+#define TTL_TYPES_INCLUDE_FILE "pipelines/TTL_schemes_common.h"
 #define DEFINING_TTL_SCHEMES_COMMON BOB
 #include "../TTL_create_types.h"
 #pragma once
 #undef DEFINING_TTL_SCHEMES_COMMON
-#pragma pop_macro("TYPES_INCLUDE_FILE")
+#pragma pop_macro("TTL_TYPES_INCLUDE_FILE")
 #else
 /**
  * @def TTL_common_buffering_t

--- a/tensors/TTL_ext_tensors.h
+++ b/tensors/TTL_ext_tensors.h
@@ -21,10 +21,10 @@
 #define TENSOR_LOCATION ext_
 #define TENSOR_ADDRESS TTL_global
 // EXT TENSORS START
-#define TYPES_INCLUDE_FILE "tensors/TTL_int_ext_typed_tensors.h"
+#define TTL_TYPES_INCLUDE_FILE "tensors/TTL_int_ext_typed_tensors.h"
 #include "../TTL_create_types.h"
 // EXT TENSORS END
-#undef TYPES_INCLUDE_FILE
+#undef TTL_TYPES_INCLUDE_FILE
 #undef TENSOR_LOCATION
 #undef TENSOR_ADDRESS
 

--- a/tensors/TTL_int_tensors.h
+++ b/tensors/TTL_int_tensors.h
@@ -21,10 +21,10 @@
 #define TENSOR_LOCATION int_
 #define TENSOR_ADDRESS TTL_local
 // INT TENSORS START
-#define TYPES_INCLUDE_FILE "tensors/TTL_int_ext_typed_tensors.h"
+#define TTL_TYPES_INCLUDE_FILE "tensors/TTL_int_ext_typed_tensors.h"
 #include "../TTL_create_types.h"
 // INT TENSORS END
-#undef TYPES_INCLUDE_FILE
+#undef TTL_TYPES_INCLUDE_FILE
 #undef TENSOR_LOCATION
 #undef TENSOR_ADDRESS
 

--- a/tensors/TTL_tensor_rw.h
+++ b/tensors/TTL_tensor_rw.h
@@ -1,0 +1,138 @@
+/*
+ * TTL_tensors_common.h
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../TTL_macros.h"
+#include "../TTL_types.h"
+
+/**
+ * @brief  Read a value from a tensor
+ *
+ * @param tensor A TTL_int_[type]_tensor_t describing the internal tensor.
+ * @param x The offset in the x dimension
+ * @param y The offset in the y dimension
+ * @param z The offset in the z dimension
+ *
+ * No bounds checking is performed.
+ *
+ * @return The value read
+ */
+static inline TTL_TENSOR_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) tensor,
+               const unsigned int x, const unsigned int y, const unsigned int z) {
+    return tensor.base[x + (tensor.layout.row_spacing * y) + (tensor.layout.plane_spacing * z)];
+}
+
+static inline TTL_TENSOR_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) tensor,
+               const unsigned int x, const unsigned int y) {
+    return TTL_read_tensor(tensor, x, y, 0);
+}
+
+static inline TTL_TENSOR_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) tensor,
+               const unsigned int x) {
+    return TTL_read_tensor(tensor, x, 0, 0);
+}
+
+/**
+ * @brief  Read a value from a tensor
+ *
+ * @param tensor A TTL_int_[type]_sub_tensor_t describing the internal tensor.
+ * @param x The offset in the x dimension
+ * @param y The offset in the y dimension
+ * @param z The offset in the z dimension
+ *
+ * No bounds checking is performed.
+ *
+ * @return The value read
+ */
+static inline TTL_TENSOR_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) sub_tensor,
+               const unsigned int x, const unsigned int y, const unsigned int z) {
+    return TTL_read_tensor(sub_tensor.tensor, x, y, z);
+}
+
+static inline TTL_TENSOR_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) sub_tensor,
+               const unsigned int x, const unsigned int y) {
+    return TTL_read_tensor(sub_tensor.tensor, x, y, 0);
+}
+
+static inline TTL_TENSOR_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) sub_tensor,
+               const unsigned int x) {
+    return TTL_read_tensor(sub_tensor.tensor, x, 0, 0);
+}
+
+/**
+ * @brief  Write a value from a tensor
+ *
+ * @param tensor A TTL_int_[type]_tensor_t describing the internal tensor.
+ * @param value The value to right
+ * @param x The offset in the x dimension
+ * @param y The offset in the y dimension
+ * @param z The offset in the z dimension
+ *
+ * @return No return value
+ */
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) tensor,
+               const TTL_TENSOR_TYPE value, const unsigned int x, const unsigned int y, const unsigned int z) {
+    tensor.base[x + (tensor.layout.row_spacing * y) + (tensor.layout.plane_spacing * z)] = value;
+}
+
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) tensor,
+               const TTL_TENSOR_TYPE value, unsigned int x, const unsigned int y) {
+    TTL_write_tensor(tensor, value, x, y, 0);
+}
+
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) tensor,
+               const TTL_TENSOR_TYPE value, const unsigned int x) {
+    TTL_write_tensor(tensor, value, x, 0, 0);
+}
+
+/**
+ * @brief  Write a value from a tensor
+ *
+ * @param tensor A TTL_int_[type]_tensor_t describing the internal tensor.
+ * @param value The value to right
+ * @param x The offset in the x dimension
+ * @param y The offset in the y dimension
+ * @param z The offset in the z dimension
+ *
+ * @return No return value
+ */
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) sub_tensor,
+               const TTL_TENSOR_TYPE value, const unsigned int x, const unsigned int y, const unsigned int z) {
+    TTL_write_tensor(sub_tensor.tensor, value, x, y, z);
+}
+
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) sub_tensor,
+               const TTL_TENSOR_TYPE value, unsigned int x, const unsigned int y) {
+    TTL_write_tensor(sub_tensor.tensor, value, x, y, 0);
+}
+
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) sub_tensor,
+               const TTL_TENSOR_TYPE value, const unsigned int x) {
+    TTL_write_tensor(sub_tensor.tensor, value, x, 0, 0);
+}


### PR DESCRIPTION
For both Tensors and SubTensors it makes a lot of sense to have standardized and typed read and write functions.

The implmentation is as follows.

TTL_read_[type]_tensor(tensor, [value_for_write], x [,y [, z]])

The return or value is the same as the type of the tensor, at present no limits checking is performed.

No method exists for a void_tensor - a tensor with a type of void as this cannot be return.

All the samples and tests are updated to include this new method and the test directory is updated with some addition changes due to tensor typing