### PR TITLE
Add CI runtime check and use available local memory

### DIFF
--- a/.github/workflows/check-c-sample.yml
+++ b/.github/workflows/check-c-sample.yml
@@ -1,0 +1,24 @@
+name: Check C Sample
+run-name: ${{ github.actor }} is checking samples
+on: [push]
+jobs:
+  Sanity-Check-C-Sample:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Info
+        run: |
+          echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+          echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+          echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Check C Sample
+        run: |
+          pip install numpy
+          ln -s $PWD TTL
+          export TTL_INCLUDE_PATH=$PWD
+          cd c/samples
+          ./TTL_sample_runner.py TTL*.c
+
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/c/samples/TTL_sample_runner.py
+++ b/c/samples/TTL_sample_runner.py
@@ -29,7 +29,7 @@ def Read(byte_array, i, j, tensor_width, element_size):
 
     for byte_index in range(0, element_size):
         result = result + (pow(256, byte_index) * byte_array[(((i * tensor_width) + j) * element_size) + byte_index])
-    
+
     return result
 
 def TestTTL(program_name):
@@ -53,7 +53,10 @@ def TestTTL(program_name):
     program_name = os.path.splitext(os.path.basename(program_name))[0]
 
     # For variation a number of tensor random sizes are used, then tiled with random tile sizes
-    for test_tensor_type, test_tensor_size in list([('char', 1), ('uchar', 1), ('short', 2), ('ushort', 2), ('int',4), ('uint',4), ('long',8), ('ulong',8)]):
+    for test_tensor_type, test_tensor_size, test_tensor_specifier in list([('char', 1, '%c'), ('uchar', 1, '%c'),
+                                                                           ('short', 2, '%d'), ('ushort', 2, '%u'),
+                                                                           ('int',4, '%d'), ('uint',4, '%u'),
+                                                                           ('long',8, '%ld'), ('ulong',8, '%lu')]):
         program_name_type = program_name + "_" + test_tensor_type + ".so"
         compile_string = (
             "rm -f "
@@ -64,13 +67,15 @@ def TestTTL(program_name):
             + test_tensor_type
             + " -DKERNEL_NAME="
             + program_name
+            + " -DTEST_TENSOR_TYPE_SPECIFIER="
+            + "\"\\\"" + test_tensor_specifier + "\\\"\""
             + " -DTTL_TARGET=c -fPIC -shared -o "
             + program_name_type
             + " "
             + program_name
             + ".c")
         os.system(compile_string)
-        
+
         print("Testing %s with %s Tensors" % (program_name, test_tensor_type))
 
         for tensor_width in random.sample(range(1, 125), 5):
@@ -119,7 +124,7 @@ def TestTTL(program_name):
                                         expected += Read(input_data, i, j + 1, tensor_width, test_tensor_size)
                                     if i < (tensor_height - 1):
                                         expected += Read(input_data, i + 1, j, tensor_width, test_tensor_size)
-                                    
+
                                 expected &= pow(256, test_tensor_size) - 1
                                 actual = Read(return_buffer, i, j, tensor_width, test_tensor_size)
 

--- a/c/samples/compute_cross.h
+++ b/c/samples/compute_cross.h
@@ -63,7 +63,8 @@ bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const e
             }
 
             if (output_buffer[0][y][x] != expected) {
-                printf("Mismatch at [%d, %d] %d != %d Tensor size [%d, %d], Tile size [%d, %d]\n",
+                printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER
+                       " Tensor size [%d, %d], Tile size [%d, %d]\n",
                        x,
                        y,
                        output_buffer[0][y][x],

--- a/opencl/samples/cpp/check_copy.h
+++ b/opencl/samples/cpp/check_copy.h
@@ -27,7 +27,7 @@ bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const e
             TEST_TENSOR_TYPE expected = input_buffer[0][y][x];
 
             if (output_buffer[0][y][x] != expected) {
-                printf("Mismatch at [%d, %d] %d != %d Tensor size [%d, %d]\n",
+                printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER " Tensor size [%d, %d]\n",
                        x,
                        y,
                        output_buffer[0][y][x],

--- a/opencl/samples/cpp/check_cross.h
+++ b/opencl/samples/cpp/check_cross.h
@@ -32,7 +32,7 @@ bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const e
             if (y < (height - 1)) expected += input_buffer[0][y + 1][x];
 
             if (output_buffer[0][y][x] != expected) {
-                printf("Mismatch at [%d, %d] %d != %d Tensor size [%d, %d]\n",
+                printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER " Tensor size [%d, %d]\n",
                        x,
                        y,
                        output_buffer[0][y][x],

--- a/opencl/samples/cpp/check_square.h
+++ b/opencl/samples/cpp/check_square.h
@@ -27,7 +27,7 @@ bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const e
             TEST_TENSOR_TYPE expected = input_buffer[0][y][x] * input_buffer[0][y][x];
 
             if (output_buffer[0][y][x] != expected) {
-                printf("Mismatch at [%d, %d] %d != %d Tensor size [%d, %d]\n",
+                printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER " Tensor size [%d, %d]\n",
                        x,
                        y,
                        output_buffer[0][y][x],

--- a/opencl/samples/cpp/test_all_types.sh
+++ b/opencl/samples/cpp/test_all_types.sh
@@ -18,11 +18,24 @@
 
 set -e
 
-for type in char uchar short ushort int uint long ulong; do
-  for compute in cross square copy; do
+if [ -z "${OPEN_CL_INCLUDE_PATH}" ]; then
+    TTL_OPEN_CL_INCLUDE_PATH=""
+else
+    TTL_OPEN_CL_INCLUDE_PATH="-I $OPEN_CL_INCLUDE_PATH"
+fi
 
-    echo Compute $compute with Tensor of type $type
-    clang -O0 -g -D TTL_TARGET=c -D TEST_TENSOR_TYPE=$type -D COMPUTE=$compute.h -D CL_TARGET_OPENCL_VERSION=300 -I $TTL_INCLUDE_PATH -I $OPEN_CL_INCLUDE_PATH -o TTL_sample_overlap TTL_sample_runner.cpp -lOpenCL -lstdc++
+# Output:
+# VAR is set to some string
+
+
+for types in char,%c uchar,%c short,%d ushort,%u int,%d uint,%u long,%ld ulong,%lu; do
+  IFS=","; set -- $types
+  type=$1
+  type_specifier=$2
+
+  for compute in cross square copy; do
+    echo Compute $compute with tensor of type $type compute of $compute
+    clang -O0 -g -D TTL_TARGET=c -D TEST_TENSOR_TYPE=$type -D TEST_TENSOR_TYPE_SPECIFIER="\"$type_specifier\"" -D COMPUTE=$compute.h -D CL_TARGET_OPENCL_VERSION=300 -I $TTL_INCLUDE_PATH $TTL_OPEN_CL_INCLUDE_PATH -o TTL_sample_overlap TTL_sample_runner.cpp -lOpenCL -lstdc++
     ./TTL_sample_overlap
 
   done

--- a/opencl/samples/python/TTL_double_buffering.cl
+++ b/opencl/samples/python/TTL_double_buffering.cl
@@ -32,22 +32,22 @@
 #undef TTL_CONST_EXT_TENSOR_TYPE
 #define TTL_CONST_EXT_TENSOR_TYPE __TTL_tensor_name(TTL_, const_, ext_, TEST_TENSOR_TYPE, , _t)
 
-#define BUFFER_SIZE 0x80000
+#define LOCAL_TILE_SIZE (LOCAL_MEMORY_SIZE / sizeof(TEST_TENSOR_TYPE) / 4)
 
 __kernel void TTL_double_buffering(__global TEST_TENSOR_TYPE *restrict ext_base_in, int external_stride_in,
                                    __global TEST_TENSOR_TYPE *restrict ext_base_out, int external_stride_out, int width,
                                    int height, int tile_width, int tile_height) {
-    local TEST_TENSOR_TYPE input_buffer_1[BUFFER_SIZE];
-    local TEST_TENSOR_TYPE input_buffer_2[BUFFER_SIZE];
-    local TEST_TENSOR_TYPE output_buffer_1[BUFFER_SIZE];
-    local TEST_TENSOR_TYPE output_buffer_2[BUFFER_SIZE];
+    local TEST_TENSOR_TYPE input_buffer_1[LOCAL_TILE_SIZE];
+    local TEST_TENSOR_TYPE input_buffer_2[LOCAL_TILE_SIZE];
+    local TEST_TENSOR_TYPE output_buffer_1[LOCAL_TILE_SIZE];
+    local TEST_TENSOR_TYPE output_buffer_2[LOCAL_TILE_SIZE];
 
     if (((TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT + tile_width) *
-         (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM + tile_height)) > BUFFER_SIZE) {
-        printf("Tile too large %d > %d\n",
+         (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM + tile_height)) > LOCAL_TILE_SIZE) {
+        printf("Tile too large %d > %lu\n",
                ((TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT + tile_width) *
                 (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM + tile_height)),
-               BUFFER_SIZE);
+               LOCAL_TILE_SIZE);
         return;
     }
 

--- a/opencl/samples/python/TTL_sample_runner.py
+++ b/opencl/samples/python/TTL_sample_runner.py
@@ -32,7 +32,6 @@ def Read(byte_array, i, j, tensor_width, element_size):
 
 def TestTTL(program_name):
     os.environ['PYOPENCL_COMPILER_OUTPUT'] = '1'
-    os.environ['PYOPENCL_CTX'] = '0'
     os.environ["PYOPENCL_NO_CACHE"] = "1"
 
     # Allow an environment variable to provide the TTL_INCLUDE_PATH, if not defined regular paths used.
@@ -48,12 +47,22 @@ def TestTTL(program_name):
         ttl_extra_defines = ""
 
     for test_tensor_type, test_tensor_size in list([('char', 1), ('uchar', 1), ('short', 2), ('ushort', 2), ('int',4), ('uint',4), ('long',8), ('ulong',8)]):
-        context = cl.create_some_context()
+        platforms = cl.get_platforms()
+        context = cl.Context(dev_type=cl.device_type.ALL,
+                             properties=[(cl.context_properties.PLATFORM, platforms[0])])
         queue = cl.CommandQueue(context)
+
+        ttl_local_memory_size = 0xfffffffff
+
+        # Provide the local memory size.
+        for device in context.get_info(cl.context_info.DEVICES):
+            ttl_local_memory_size = min(device.get_info(cl.device_info.LOCAL_MEM_SIZE), ttl_local_memory_size)
 
         # For convenience remove the .cl extension if it included.
         program_name = os.path.splitext(program_name)[0]
-        program = cl.Program(context, open(program_name+'.cl').read()).build(options=ttl_include_path + ttl_extra_defines + " -DTTL_COPY_3D -DTEST_TENSOR_TYPE=" + test_tensor_type)
+        program = cl.Program(context, open(program_name+'.cl').read()).build(options=ttl_include_path + ttl_extra_defines +
+                                                                             " -DTTL_COPY_3D -DTEST_TENSOR_TYPE=" + test_tensor_type +
+                                                                             " -DLOCAL_MEMORY_SIZE=" + str(ttl_local_memory_size))
 
         print("Testing %s with %s Tensors" % (program_name, test_tensor_type))
 

--- a/opencl/samples/python/TTL_simplex_buffering.cl
+++ b/opencl/samples/python/TTL_simplex_buffering.cl
@@ -1,20 +1,20 @@
 /*
-* ttl_simplex_buffering.cl
-*
-* Copyright (c) 2023 Mobileye
-*
-* Licensed under the Apache License, Version 2.0 (the License);
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an AS IS BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * ttl_simplex_buffering.cl
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "TTL/TTL.h"
 #include "compute_cross.h"
@@ -26,19 +26,28 @@
 #undef TTL_EXT_TENSOR_TYPE
 #define TTL_EXT_TENSOR_TYPE __TTL_tensor_name(TTL_, , ext_, TEST_TENSOR_TYPE, , _t)
 
-#define MEMSZ 0x8000
+#define LOCAL_TILE_SIZE (LOCAL_MEMORY_SIZE / sizeof(TEST_TENSOR_TYPE) / 3)
 
 __kernel void TTL_simplex_buffering(__global TEST_TENSOR_TYPE *restrict ext_base_in, int external_stride_in,
-                                    __global TEST_TENSOR_TYPE *restrict ext_base_out, int external_stride_out, int width,
-                                    int height, int tile_width, int tile_height) {
-    __local TEST_TENSOR_TYPE l_buff1[MEMSZ];
-    __local TEST_TENSOR_TYPE l_buff2[MEMSZ];
-    __local TEST_TENSOR_TYPE l_buff3[MEMSZ];
+                                    __global TEST_TENSOR_TYPE *restrict ext_base_out, int external_stride_out,
+                                    int width, int height, int tile_width, int tile_height) {
+    __local TEST_TENSOR_TYPE l_buff1[LOCAL_TILE_SIZE];
+    __local TEST_TENSOR_TYPE l_buff2[LOCAL_TILE_SIZE];
+    __local TEST_TENSOR_TYPE l_buff3[LOCAL_TILE_SIZE];
+
+    if (((TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT + tile_width) *
+         (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM + tile_height)) > LOCAL_TILE_SIZE) {
+        printf("Tile too large %d > %lu\n",
+               ((TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT + tile_width) *
+                (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM + tile_height)),
+               LOCAL_TILE_SIZE);
+        return;
+    }
 
     // Logical input tiling.
     const TTL_shape_t tensor_shape_in = TTL_create_shape(width, height);
     const TTL_shape_t tile_shape_in = TTL_create_shape(tile_width + (TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT),
-                                                          tile_height + (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM));
+                                                       tile_height + (TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM));
     const TTL_overlap_t overlap_in =
         TTL_create_overlap(TILE_OVERLAP_LEFT + TILE_OVERLAP_RIGHT, TILE_OVERLAP_TOP + TILE_OVERLAP_BOTTOM);
     const TTL_augmentation_t augmentation_in =
@@ -60,13 +69,13 @@ __kernel void TTL_simplex_buffering(__global TEST_TENSOR_TYPE *restrict ext_base
     TTL_event_t tb_e_in = TTL_get_event();
     TTL_event_t tb_e_out = TTL_get_event();
     TTL_SIMPLEX_BUFFERING_TYPE simplex_scheme = TTL_start_simplex_buffering(l_buff1,
-                                                                    l_buff2,
-                                                                    l_buff3,
-                                                                    ext_input_tensor,
-                                                                    ext_output_tensor,
-                                                                    &tb_e_in,
-                                                                    &tb_e_out,
-                                                                    TTL_get_tile(0, input_tiler));
+                                                                            l_buff2,
+                                                                            l_buff3,
+                                                                            ext_input_tensor,
+                                                                            ext_output_tensor,
+                                                                            &tb_e_in,
+                                                                            &tb_e_out,
+                                                                            TTL_get_tile(0, input_tiler));
 
     for (int i = 0; i < TTL_number_of_tiles(input_tiler); ++i) {
         TTL_tile_t tile_next_import = TTL_get_tile(i + 1, input_tiler);


### PR DESCRIPTION
A small number of bugs/issues had crept into the code and so a CI runtime of the C samples as been added to try to prevent this.

The issues fixed are

Not using the actually available local memory to allocate buffers, this is fixed by querying the amount of available memory before complication.

The memory of the targets is now queried by the host side before compilitation and based as a macro called LOCAL_MEMORY_SIZE.

A second macro for the samples with a host side written in Python is to pass the printf specifier for the type to remove a warning when the Tensor type is long or unsigned long.