### PR TITLE
Mixed definitions cause problems for some tool sets.

### DIFF
--- a/c/TTL_import_export.h
+++ b/c/TTL_import_export.h
@@ -49,7 +49,7 @@ static inline void wait_group_events(int num_events, event_t *event_list) {
     // Nothing to do in C we have no events.
 }
 
-static event_t async_work_group_copy_3D3D(void *dst, size_t dst_offset, const void *src, size_t src_offset,
+static event_t async_work_group_copy_3D3D(void *const dst, size_t dst_offset, const void *const src, size_t src_offset,
                                    size_t num_bytes_per_element, size_t num_elements_per_line, size_t num_lines,
                                    size_t num_planes, size_t src_total_line_length, size_t src_total_plane_spacing,
                                    size_t dst_total_line_length, size_t dst_total_plane_spacing, event_t event) {

--- a/c/samples/TTL_double_buffering.c
+++ b/c/samples/TTL_double_buffering.c
@@ -18,6 +18,7 @@
 
 #include "TTL/TTL.h"
 #include "compute_cross.h"
+#include "kernel.h"
 
 /**
  * @brief Scope globally because it makes debugging easier

--- a/c/samples/TTL_duplex_buffering.c
+++ b/c/samples/TTL_duplex_buffering.c
@@ -19,6 +19,7 @@
 #include "TTL/TTL.h"
 
 #include "compute_cross.h"
+#include "kernel.h"
 
 /**
  * @brief Scope globally because it makes debugging easier

--- a/c/samples/TTL_simplex_buffering.c
+++ b/c/samples/TTL_simplex_buffering.c
@@ -18,6 +18,7 @@
 
 #include "TTL/TTL.h"
 #include "compute_cross.h"
+#include "kernel.h"
 
 /**
  * @brief Scope globally because it makes debugging easier

--- a/c/samples/compute_cross.h
+++ b/c/samples/compute_cross.h
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#include <stdbool.h>
+
 #include "TTL/TTL.h"
 
 #define TILE_OVERLAP_LEFT 1

--- a/c/samples/kernel.h
+++ b/c/samples/kernel.h
@@ -1,0 +1,21 @@
+/*
+ * kernel.h
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+bool KERNEL_NAME(TEST_TENSOR_TYPE *restrict ext_base_in, int external_stride_in,
+                 TEST_TENSOR_TYPE *restrict ext_base_out, int external_stride_out, int width, int height,
+                 int tile_width, int tile_height);

--- a/c/samples/main.c
+++ b/c/samples/main.c
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #define TENSOR_WIDTH 103
 #define TENSOR_HEIGHT 27
@@ -25,12 +26,8 @@
 #define TILE_HEIGHT 1
 
 #include "TTL/TTL.h"
-
+#include "kernel.h"
 typedef unsigned int unsigned_int;
-
-bool KERNEL_NAME(TEST_TENSOR_TYPE *restrict ext_base_in, int external_stride_in,
-                 TEST_TENSOR_TYPE *restrict ext_base_out, int external_stride_out, int width, int height,
-                 int tile_width, int tile_height);
 
 static TEST_TENSOR_TYPE input_buffer[TENSOR_HEIGHT][TENSOR_WIDTH];
 static TEST_TENSOR_TYPE output_buffer[TENSOR_HEIGHT][TENSOR_WIDTH];

--- a/opencl/TTL_async_work_group_copy_3D3D.h
+++ b/opencl/TTL_async_work_group_copy_3D3D.h
@@ -27,7 +27,7 @@
  * This is an implementation that can be included by defining TTL_COPY_3D
  */
 __attribute__((overloadable)) event_t async_work_group_copy_3D3D(
-    __local void *dst, size_t dst_offset, const __global void *src, size_t src_offset, size_t num_bytes_per_element,
+    __local void *const dst, size_t dst_offset, const __global void *const src, size_t src_offset, size_t num_bytes_per_element,
     size_t num_elements_per_line, size_t num_lines, size_t num_planes, size_t src_total_line_length,
     size_t src_total_plane_spacing, size_t dst_total_line_length, size_t dst_total_plane_spacing, event_t event) {
     for (size_t plane = 0; plane < num_planes; plane++) {
@@ -52,7 +52,7 @@ __attribute__((overloadable)) event_t async_work_group_copy_3D3D(
  * This is an implementation that can be included by defining TTL_COPY_3D
  */
 __attribute__((overloadable)) event_t async_work_group_copy_3D3D(
-    __global void *dst, size_t dst_offset, const __local void *src, size_t src_offset, size_t num_bytes_per_element,
+    __global void *const dst, size_t dst_offset, const __local void *const src, size_t src_offset, size_t num_bytes_per_element,
     size_t num_elements_per_line, size_t num_lines, size_t num_planes, size_t src_total_line_length,
     size_t src_total_plane_spacing, size_t dst_total_line_length, size_t dst_total_plane_spacing, event_t event) {
     for (size_t plane = 0; plane < num_planes; plane++) {

--- a/pipelines/TTL_double_scheme.h
+++ b/pipelines/TTL_double_scheme.h
@@ -82,7 +82,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_IMPORT_DOUBLE_BUFFERING_TYPE *const db, c
  *
  */
 static inline TTL_INT_SUB_TENSOR_TYPE __attribute__((overloadable))
-__TTL_TRACE_FN(TTL_step_buffering, TTL_EXPORT_DOUBLE_BUFFERING_TYPE *db, TTL_tile_t tile_current) {
+__TTL_TRACE_FN(TTL_step_buffering, TTL_EXPORT_DOUBLE_BUFFERING_TYPE *const db, TTL_tile_t tile_current) {
     const TTL_layout_t int_layout = TTL_create_layout(db->prev_tile.shape.width, db->prev_tile.shape.height);
     const TTL_CONST_INT_TENSOR_TYPE export_from = TTL_create_const_int_tensor(
         db->common.int_base[db->common.index], db->prev_tile.shape, int_layout, db->common.ext_tensor_in.elem_size);

--- a/pipelines/TTL_double_scheme_template.h
+++ b/pipelines/TTL_double_scheme_template.h
@@ -19,13 +19,13 @@
 // clang-format off
 /**
  * @file
- * 
+ *
  * TTL_double_buffering pipelines a duplex import or export transaction using two
  * internal buffers.
- * 
+ *
  * The following table draws the pipelined actions performed in double buffering.
  * It specifies which tile is processed in each iteration:
- * 
+ *
  * | Action\\Iteration | \#-1 | \#0 | \#1 | \#2 | \#i (2:NumOfTiles-2) | \#NumOfTiles-1 | \#NumOfTiles | \#NumOfTiles+1 |
  * |-------------------|------|-----|-----|-----|----------------------|----------------|--------------|----------------|
  * | **Wait Import**   |      | 0   | 1   | 2   | i                    | NumOfTiles-1   |              |                |
@@ -33,7 +33,7 @@
  * | **WaitExport**    |      |     |     | 0   | i-2                  | NumOfTiles-3   | NumOfTiles-2 | NumOfTiles-1   |
  * | **Export**        |      |     | 0   | 1   | i-1                  | NumOfTiles-2   | NumOfTiles-1 |                |
  * | **Compute**       |      | 0   | 1   | 2   | i                    | NumOfTiles-1   |              |                |
- * 
+ *
  * Notice the prolog (at iteration number -1) and the 2 epilogs (at iterations
  * number NumOfTiles and NumOfTiles+1) which add in total 3 extra iterations.
  *

--- a/pipelines/TTL_duplex_scheme.h
+++ b/pipelines/TTL_duplex_scheme.h
@@ -39,13 +39,13 @@
  * | **WaitExport**    |     | 0   | i-1                  | NumOfTiles-1  |
  *
  * Notice the epilog (\#NumOfTiles) which is an extra iteration.
- * 
+ *
  * When including this file the following must be defined
- * 
+ *
  * #define TTL_TENSOR_TYPE void
  * #define TTL_TENSOR_TYPE uchar
  * etc
- * 
+ *
  * @example TTL_duplex_buffering.cl
  */
 // clang-format on
@@ -96,7 +96,7 @@ typedef struct {
  * Predeclare TTL_step_buffering.
  */
 static inline TTL_IO_TENSOR_TYPE __attribute__((overloadable))
-__TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *duplex_buffering, TTL_tile_t tile_next_import,
+__TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *const duplex_buffering, TTL_tile_t tile_next_import,
                TTL_tile_t tile_current_export);
 
 /**
@@ -204,7 +204,7 @@ __TTL_TRACE_FN(TTL_start_duplex_buffering, TTL_EXT_TENSOR_TYPE ext_tensor_in, TT
 }
 
 static inline TTL_IO_TENSOR_TYPE __attribute__((overloadable))
-__TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *duplex_buffering, TTL_tile_t tile_current_import,
+__TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *const duplex_buffering, TTL_tile_t tile_current_import,
                TTL_tile_t tile_current_export) {
     const TTL_layout_t next_import_layout =
         TTL_create_layout(tile_current_import.shape.width, tile_current_import.shape.height);
@@ -258,6 +258,6 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *duplex_buffering, 
 }
 
 static inline void __attribute__((overloadable))
-__TTL_TRACE_FN(TTL_finish_buffering, TTL_DUPLEX_BUFFERING_TYPE *duplex_buffering) {
+__TTL_TRACE_FN(TTL_finish_buffering, TTL_DUPLEX_BUFFERING_TYPE *const duplex_buffering) {
     TTL_step_buffering(duplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
 }

--- a/pipelines/TTL_simplex_scheme.h
+++ b/pipelines/TTL_simplex_scheme.h
@@ -24,15 +24,15 @@
  * three internal buffers, in rotation: each buffer interchangeably serves as input
  * buffer and output buffer, such that in each iteration one buffer is used both to
  * export then import and two buffers are used by compute for reading and writing.
- * 
+ *
  * With simplex buffering we're only waiting for previous iterations, so DMA
  * transactions run mostly in parallel to computation, but serially with each
  * other. Using the same buffer both for import and export is possible allowing us
  * to overlap exporting from and importing to the same buffer.
- * 
+ *
  * The following table draws the pipelined actions performed in simplex buffering.
  * It specifies which tile is processed in each iteration:
- * 
+ *
  * | Action\\Iteration | \#-1 | \#0 | \#1 | \#2 | \#i (2:NumOfTiles-2) | \#NumOfTiles-1 | \#NumOfTiles | \#NumOfTiles+1 |
  * |-------------------|------|-----|-----|-----|----------------------|----------------|--------------|----------------|
  * | **WaitExport**    |      |     |     | 0   | i-2                  | NumOfTiles-3   | NumOfTiles-2 | NumOfTiles-1   |
@@ -40,7 +40,7 @@
  * | **Wait Import**   |      | 0   | 1   | 2   | i                    | NumOfTiles-1   |              |                |
  * | **Import**        | 0    | 1   | 2   | 3   | i+1                  |                |              |                |
  * | **Compute**       |      | 0   | 1   | 2   | i                    | NumOfTiles-1   |              |                |
- * 
+ *
  * Notice the prolog (at iteration number -1) and the 2 epilogs (at iterations
  * number NumOfTiles and NumOfTiles+1) which add in total 3 extra iterations.
  *
@@ -88,7 +88,7 @@ typedef struct {
  * Simple declarations for file ordering purposes
  */
 static inline TTL_IO_TENSOR_TYPE __attribute__((overloadable))
-__TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *simplex_buffer, TTL_tile_t tile_next_import,
+__TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *const simplex_buffer, TTL_tile_t tile_next_import,
                TTL_tile_t tile_current_export);
 
 /**
@@ -158,7 +158,7 @@ __TTL_TRACE_FN(TTL_start_simplex_buffering, TTL_local(TTL_TENSOR_TYPE *) int_bas
 }
 
 static inline TTL_IO_TENSOR_TYPE __attribute__((overloadable))
-__TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *simplex_buffer, TTL_tile_t tile_next_import,
+__TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *const simplex_buffer, TTL_tile_t tile_next_import,
                TTL_tile_t tile_current_export) {
     // For performance, compute everything possible before waiting for the previous operations to finish. The current
     // index contains the tile that is to be exported, so prepare the structures before beginning the export and export.
@@ -231,7 +231,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *simplex_buffer, T
 }
 
 static inline void __attribute__((overloadable))
-__TTL_TRACE_FN(TTL_finish_buffering, TTL_SIMPLEX_BUFFERING_TYPE *simplex_buffering) {
+__TTL_TRACE_FN(TTL_finish_buffering, TTL_SIMPLEX_BUFFERING_TYPE *const simplex_buffering) {
     TTL_step_buffering(simplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
     TTL_step_buffering(simplex_buffering, TTL_create_empty_tile(), TTL_create_empty_tile() __TTL_TRACE_LINE);
 }


### PR DESCRIPTION
TTL contains code code that looks like the follow

//
static inline TTL_int_void_sub_tensor_t attribute((overloadable)) TTL_step_buffering(TTL_import_double_const_void_tensor_buffering_t *const db, const TTL_tile_t next_tile);

...snip

result.prev_tile = TTL_create_empty_tile();

TTL_step_buffering(&result, first_tile);

return result;
}

...snip

static inline TTL_int_void_sub_tensor_t attribute((overloadable)) TTL_step_buffering(TTL_import_double_const_void_tensor_buffering_t *db, const TTL_tile_t next_tile) { const TTL_layout_t int_layout = TTL_create_layout(next_tile.shape.width, next_tile.shape.height); const TTL_int_void_sub_tensor_t import_to = TTL_create_int_sub_tensor( ...

Note the const is not present in the declaration but is in the pre-definition; technically, this is not incorrect and, in most cases, is compiled. However, some tools incorrectly generate different overload signatures, and so fail to link.

Could you update all the cases where this difference happens?

Whilst investigating this a kernel.h file was created for the c samples and so this is also landed as part of this patch.