### PR TITLE
Add ability to record and replay lists of ASync copies

### DIFF
--- a/TTL_macros.h
+++ b/TTL_macros.h
@@ -127,7 +127,7 @@
  * __TTL_tensor_name(TTL_, ,int, void, , _t) will give TTL_int_void_tensor_t
  *
  * The 'double' call is some 'magic' to allow the caller itself to contain a macro.
- * 
+ *
  * @return The generated name
  */
 #define __TTL_tensor_name_1(prefix, const_1, location, type, sub, suffix) \
@@ -156,10 +156,15 @@
  * __TTL_tensor_no_type_name(TTL_, ,int, , _t) will give TTL_int_tensor_t
  *
  * The 'double' call is some 'magic' to allow the caller itself to contain a macro.
- * 
+ *
  * @return The generated name
  */
 #define __TTL_tensor_no_type_name_1(prefix, const_1, location, sub, suffix) \
     prefix##const_1##location##sub##tensor##suffix
 #define __TTL_tensor_no_type_name(prefix, const_1, location, sub, suffix) \
     __TTL_tensor_no_type_name_1(prefix, const_1, location, sub, suffix)
+
+
+#ifndef min
+#define min(X, Y) (((X) < (Y)) ? (X) : (Y))
+#endif

--- a/TTL_types.h
+++ b/TTL_types.h
@@ -225,3 +225,35 @@ TTL_create_overlap(const TTL_overlap_dim_t width, const TTL_overlap_dim_t height
 static inline TTL_overlap_t __attribute__((overloadable)) TTL_create_overlap(const TTL_overlap_dim_t width) {
     return TTL_create_overlap(width, 0, 0);
 }
+
+// TEMP WILL BE PROVIDED BY THE COMPILER
+#define CLK_ASYNC_LINKED_LIST_NODE_SIZE 20
+
+/**
+ * @brief An async copy list node
+ *
+ * When performing gather type operations on async inputs, each gathered entity is
+ * stored in a TTL_async_node_data
+ *
+ * The contents of the node are target specific, thes structure eases the
+ * manipulation and usage of nodes
+ */
+typedef struct {
+    unsigned char anonymous_data[CLK_ASYNC_LINKED_LIST_NODE_SIZE];
+} TTL_async_node_data;
+
+/**
+ * @brief Map a index on the row to a physical index and height on the source
+ */
+typedef struct {
+    TTL_offset_dim_t row_offset;  ///< The start point of the row
+    TTL_dim_t row_count;       ///< The number of rows in the index
+} TTL_row_gather_map_element;
+
+/**
+ * @brief Map a index on the row to a physical index and height on the source
+ */
+typedef struct {
+    TTL_row_gather_map_element *elements;  ///< The elements in the map
+    unsigned int element_count;       ///< The number of elements in the map
+} TTL_row_gather_map;

--- a/c/samples/README.md
+++ b/c/samples/README.md
@@ -23,14 +23,14 @@ The name can be wildcarded
     ./TTL_sample_runner.py TTL_*.c
 
 TTL_EXTRA_DEFINES can for example define __TTL_DEBUG=1 to provide additional
-debug output. 
+debug output.
 
     export TTL_EXTRA_DEFINES="__TTL_DEBUG=1"
 
 ## C Wrapper
 
     export TTL_INCLUDE_PATH=[PATH TO TTL]
-    clang -Wextra -Wall -DKERNEL_NAME=TTL_duplex_buffering -I $TTL_INCLUDE_PATH -DTTL_TARGET=c -g -O0 main.c TTL_duplex_buffering.c -o c_test
+    clang -Wextra -Wall -DKERNEL_NAME=TTL_duplex_buffering -DEVERY_N_LINES=1 -DTEST_TENSOR_TYPE_SPECIFIER=\"%d\" -DTEST_TENSOR_TYPE=int -I $TTL_INCLUDE_PATH -DTTL_TARGET=c -g -O0 main.c TTL_duplex_buffering.c -o c_test
     ./c_test
 
 ## The "Kernel"
@@ -57,4 +57,4 @@ a fairly broad-based testing.
 
 The compute.h file which contains the calculations also contains a checker function. This checker function and a checker
 function in the ./TTL_sample_runner.py file validate the tiled calculations.
-  
+

--- a/c/samples/compute_cross.h
+++ b/c/samples/compute_cross.h
@@ -25,8 +25,8 @@
 
 void compute(__TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_in,
              __TTL_tensor_name(TTL_, , int_, TEST_TENSOR_TYPE, sub_, _t) tensor_out) {
-    for (int y = 0; y < tensor_out.tensor.shape.height; ++y) {
-        for (int x = 0; x < tensor_out.tensor.shape.width; ++x) {
+    for (unsigned int y = 0; y < tensor_out.tensor.shape.height; ++y) {
+        for (unsigned int x = 0; x < tensor_out.tensor.shape.width; ++x) {
             const int x_in = x + TILE_OVERLAP_LEFT;
             const int y_in = y + TILE_OVERLAP_TOP;
             const TEST_TENSOR_TYPE left = TTL_read_tensor(tensor_in, x_in - 1, y_in);
@@ -49,20 +49,20 @@ bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const e
     TEST_TENSOR_TYPE(*const output_buffer)[height][width] = (TEST_TENSOR_TYPE(*)[height][width])ext_base_out;
     bool result = true;
 
-    for (int y = 0; y < height; y++) {
+    for (int y = 0; y < height; y+=EVERY_N_LINES) {
         for (int x = 0; x < width; x++) {
             TEST_TENSOR_TYPE expected = input_buffer[0][y][x];
 
             if (true) {
                 if (x > 0) expected += input_buffer[0][y][x - 1];
-                if (y > 0) expected += input_buffer[0][y - 1][x];
+                if (y >= EVERY_N_LINES) expected += input_buffer[0][y - EVERY_N_LINES][x];
                 if (x < (width - 1)) expected += input_buffer[0][y][x + 1];
-                if (y < (height - 1)) expected += input_buffer[0][y + 1][x];
+                if (y < (height - EVERY_N_LINES)) expected += input_buffer[0][y + EVERY_N_LINES][x];
             }
 
             if (output_buffer[0][y][x] != expected) {
                 printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER
-                       " Tensor size [%d, %d], Tile size [%d, %d]\n",
+                       "Output Tensor size [%d, %d], Tile size [%d, %d]\n",
                        x,
                        y,
                        output_buffer[0][y][x],

--- a/c/samples/main.c
+++ b/c/samples/main.c
@@ -19,10 +19,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#define TENSOR_WIDTH 103
-#define TENSOR_HEIGHT 27
-#define TILE_WIDTH 1
-#define TILE_HEIGHT 1
+#define TENSOR_WIDTH 10
+#define TENSOR_HEIGHT 20
+#define TILE_WIDTH 10
+#define TILE_HEIGHT 10
 
 #include "TTL/TTL.h"
 
@@ -32,13 +32,15 @@ bool KERNEL_NAME(TEST_TENSOR_TYPE *restrict ext_base_in, int external_stride_in,
                  TEST_TENSOR_TYPE *restrict ext_base_out, int external_stride_out, int width, int height,
                  int tile_width, int tile_height);
 
-static TEST_TENSOR_TYPE input_buffer[TENSOR_HEIGHT][TENSOR_WIDTH];
+static TEST_TENSOR_TYPE input_buffer[TENSOR_HEIGHT * EVERY_N_LINES][TENSOR_WIDTH];
 static TEST_TENSOR_TYPE output_buffer[TENSOR_HEIGHT][TENSOR_WIDTH];
 
 int main(void) {
-    for (uint32_t y = 0; y < TENSOR_HEIGHT; y++) {
-        for (uint32_t x = 0; x < TENSOR_WIDTH; x++) {
+    for (uint32_t x = 0; x < TENSOR_WIDTH; x++) {
+        for (uint32_t y = 0; y < (TENSOR_HEIGHT * EVERY_N_LINES); y++) {
             input_buffer[y][x] = x;
+        }
+        for (uint32_t y = 0; y < TENSOR_HEIGHT; y++) {
             output_buffer[y][x] = 0;
         }
     }

--- a/opencl/samples/python/TTL_sample_runner.py
+++ b/opencl/samples/python/TTL_sample_runner.py
@@ -31,7 +31,7 @@ def Read(byte_array, i, j, tensor_width, element_size):
     return result
 
 def TestTTL(program_name):
-    os.environ['PYOPENCL_COMPILER_OUTPUT'] = '1'
+    os.environ['PYOPENCL_COMPILER_OUTPUT'] = "1"
     os.environ["PYOPENCL_NO_CACHE"] = "1"
 
     # Allow an environment variable to provide the TTL_INCLUDE_PATH, if not defined regular paths used.
@@ -45,6 +45,8 @@ def TestTTL(program_name):
         ttl_extra_defines =  " " + os.environ["TTL_EXTRA_DEFINES"] + " "
     else:
         ttl_extra_defines = ""
+
+    every_n_lines = 2
 
     for test_tensor_type, test_tensor_size in list([('char', 1), ('uchar', 1), ('short', 2), ('ushort', 2), ('int',4), ('uint',4), ('long',8), ('ulong',8)]):
         platforms = cl.get_platforms()
@@ -62,6 +64,7 @@ def TestTTL(program_name):
         program_name = os.path.splitext(program_name)[0]
         program = cl.Program(context, open(program_name+'.cl').read()).build(options=ttl_include_path + ttl_extra_defines +
                                                                              " -DTTL_COPY_3D -DTEST_TENSOR_TYPE=" + test_tensor_type +
+                                                                             " -DEVERY_N_LINES=" + str(every_n_lines) +
                                                                              " -DLOCAL_MEMORY_SIZE=" + str(ttl_local_memory_size))
 
         print("Testing %s with %s Tensors" % (program_name, test_tensor_type))

--- a/tensors/TTL_tensors_common.h
+++ b/tensors/TTL_tensors_common.h
@@ -292,7 +292,7 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
      * As above but a dummy parameter is used to select the version to all                                        \
      */                                                                                                           \
     static inline __TTL_tensor_name(TTL_, const_1, location, type, , _t) __attribute__((overloadable))            \
-        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, , )(TTL_scope(type *) unused) {                            \
+        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, , )(TTL_scope(type *) unused) {           \
         (void)unused;                                                                                             \
         return __TTL_tensor_name(TTL_create_empty_, const_1, location, type, , )();                               \
     }
@@ -403,20 +403,19 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
         return result;                                                                                                \
     }                                                                                                                 \
                                                                                                                       \
-    /**                                                                                                                \
-     * @brief Create an empty location sub tensor. Empty means it has all dimensions set                                   \
-     * to zero                                                                                                         \
-     *                                                                                                                 \
-     * @param unused Simply defined to allow selection of the functon to call.                                         \
-     *                                                                                                                 \
-     * As above but a dummy parameter is used to select the version to all                                             \
-     */                                                                                                                \
-    static inline __TTL_tensor_name(TTL_, const_1, location, type, sub_, _t) __attribute__((overloadable))                 \
-        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, sub_, )(TTL_scope(type *) unused) {                                 \
-        (void)unused;                                                                                                  \
-        return __TTL_tensor_name(TTL_create_empty_, const_1, location, type, sub_, )();                                    \
+    /**                                                                                                               \
+     * @brief Create an empty location sub tensor. Empty means it has all dimensions set                              \
+     * to zero                                                                                                        \
+     *                                                                                                                \
+     * @param unused Simply defined to allow selection of the functon to call.                                        \
+     *                                                                                                                \
+     * As above but a dummy parameter is used to select the version to all                                            \
+     */                                                                                                               \
+    static inline __TTL_tensor_name(TTL_, const_1, location, type, sub_, _t) __attribute__((overloadable))            \
+        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, sub_, )(TTL_scope(type *) unused) {           \
+        (void)unused;                                                                                                 \
+        return __TTL_tensor_name(TTL_create_empty_, const_1, location, type, sub_, )();                               \
     }
-
 
 /************************************************************************************************************
  * Create the create tensor functions for different overloads
@@ -511,6 +510,33 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
      * @param base The ## TTL_scope ## base address of the tensor in ## location ## memory                        \
      * @param shape Description of the shape of the tensor that base points                                       \
      * @param layout The layout of the ## location ## tensor                                                      \
+     * @param offset The offset from the base to place the tensor                                                 \
+     * @param origin_tensor The tensor that originated the sub tensor                                             \
+     * @param sub_offset The offset of the tensor from the souce tensor. @see TTL_offset_t                        \
+     *                                                                                                            \
+     * @details                                                                                                   \
+     * The element size of the tensor is taken from the origin tensor                                             \
+     * The offset of the sub tensor is taken to be (0, 0, 0)                                                      \
+     *                                                                                                            \
+     * @return return a __TTL_tensor_name(TTL_, const_1, location, type, sub, _t)                                 \
+     */                                                                                                           \
+    static inline __TTL_tensor_name(TTL_, const_1, location, type, sub, _t) __attribute__((overloadable))         \
+        __TTL_tensor_overloaded_name(TTL_create_, const_1, location, type, sub, )(                                \
+            TTL_scope(const_2 type *) const base,                                                                 \
+            const TTL_shape_t shape,                                                                              \
+            const TTL_layout_t layout,                                                                            \
+            const TTL_offset_t offset,                                                                            \
+            const __TTL_tensor_name(TTL_, const_, ext_, type, , _t) origin_tensor,                                \
+            const TTL_offset_t sub_offset) {                                                                      \
+        return __TTL_tensor_overloaded_name(TTL_create_, const_1, location, type, sub, )(                         \
+            base, shape, layout, origin_tensor.elem_size, offset, origin_tensor.shape, sub_offset);               \
+    }                                                                                                             \
+    /**                                                                                                           \
+     * @brief  __TTL_tensor_name(TTL_create_, const_1, location, type, sub, _5_params)                            \
+     *                                                                                                            \
+     * @param base The ## TTL_scope ## base address of the tensor in ## location ## memory                        \
+     * @param shape Description of the shape of the tensor that base points                                       \
+     * @param layout The layout of the ## location ## tensor                                                      \
      * @param origin_tensor The tensor that originated the sub tensor                                             \
      * @param sub_offset The offset of the tensor from the souce tensor. @see TTL_offset_t                        \
      *                                                                                                            \
@@ -582,4 +608,3 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
                                                                                          origin_tensor.shape,     \
                                                                                          TTL_create_offset());    \
     }
-    


### PR DESCRIPTION
By linking togeather a multiple ASync copies into a single user level transation the opportunity for gather scatter type operations becomes possible.

This patch only allows this in the row axis, which may be the only axis that makes sense due to the nature of the underlying storage.

An income tensor can be gathered in any order, for example.

A 10 row global Tensor could be mapped to a 4 row local tensor with the following mapping
Global Row 1 -> Local Row 1
Global Row 6,7 -> Local Row 2,3
Global Row 3 -> Local Row 4

The mapping is passed to the tiler, and from that point forwards is invisible to the user.