### PR TITLE
Add the ability to Align Tensor Rows and Planes

### DIFF
--- a/c/samples/TTL_double_buffering.c
+++ b/c/samples/TTL_double_buffering.c
@@ -60,8 +60,8 @@ bool TTL_double_buffering(TEST_TENSOR_TYPE *restrict ext_base_in, int external_s
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_CONST_EXT_TENSOR_TYPE ext_input_tensor =
         TTL_create_const_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);

--- a/c/samples/TTL_duplex_buffering.c
+++ b/c/samples/TTL_duplex_buffering.c
@@ -55,8 +55,8 @@ bool TTL_duplex_buffering(TEST_TENSOR_TYPE *restrict ext_base_in, int external_s
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_EXT_TENSOR_TYPE ext_input_tensor = TTL_create_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
     const TTL_EXT_TENSOR_TYPE ext_output_tensor = TTL_create_ext_tensor(ext_base_out, tensor_shape_out, ext_layout_out);

--- a/c/samples/TTL_simplex_buffering.c
+++ b/c/samples/TTL_simplex_buffering.c
@@ -53,8 +53,8 @@ bool TTL_simplex_buffering(TEST_TENSOR_TYPE *restrict ext_base_in, int external_
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_EXT_TENSOR_TYPE ext_input_tensor = TTL_create_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
     const TTL_EXT_TENSOR_TYPE ext_output_tensor = TTL_create_ext_tensor(ext_base_out, tensor_shape_out, ext_layout_out);

--- a/opencl/samples/cpp/check_copy.h
+++ b/opencl/samples/cpp/check_copy.h
@@ -16,21 +16,20 @@
  * limitations under the License.
  */
 
-bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const ext_base_out, const int width,
+template <typename TestTensor>
+bool result_check(const TestTensor&  ext_base_in, const TestTensor& ext_base_out, const int width,
                   const int height) {
-#define input_buffer ((TEST_TENSOR_TYPE(*)[height][width])ext_base_in)
-#define output_buffer ((TEST_TENSOR_TYPE(*)[height][width])ext_base_out)
     bool result = true;
 
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
-            TEST_TENSOR_TYPE expected = input_buffer[0][y][x];
+            TEST_TENSOR_TYPE expected = ext_base_in[y][x];
 
-            if (output_buffer[0][y][x] != expected) {
+            if (ext_base_out[y][x] != expected) {
                 printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER " Tensor size [%d, %d]\n",
                        x,
                        y,
-                       output_buffer[0][y][x],
+                       ext_base_out[y][x],
                        expected,
                        width,
                        height);

--- a/opencl/samples/cpp/check_cross.h
+++ b/opencl/samples/cpp/check_cross.h
@@ -16,26 +16,25 @@
  * limitations under the License.
  */
 
-bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const ext_base_out, const int width,
+template <typename TestTensor>
+bool result_check(const TestTensor&  ext_base_in, const TestTensor& ext_base_out, const int width,
                   const int height) {
-#define input_buffer ((TEST_TENSOR_TYPE(*)[height][width])ext_base_in)
-#define output_buffer ((TEST_TENSOR_TYPE(*)[height][width])ext_base_out)
     bool result = true;
 
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
-            TEST_TENSOR_TYPE expected = input_buffer[0][y][x];
+            TEST_TENSOR_TYPE expected = ext_base_in[y][x];
 
-            if (x > 0) expected += input_buffer[0][y][x - 1];
-            if (y > 0) expected += input_buffer[0][y - 1][x];
-            if (x < (width - 1)) expected += input_buffer[0][y][x + 1];
-            if (y < (height - 1)) expected += input_buffer[0][y + 1][x];
+            if (x > 0) expected += ext_base_in[y][x - 1];
+            if (y > 0) expected += ext_base_in[y - 1][x];
+            if (x < (width - 1)) expected += ext_base_in[y][x + 1];
+            if (y < (height - 1)) expected += ext_base_in[y + 1][x];
 
-            if (output_buffer[0][y][x] != expected) {
+            if (ext_base_out[y][x] != expected) {
                 printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER " Tensor size [%d, %d]\n",
                        x,
                        y,
-                       output_buffer[0][y][x],
+                       ext_base_out[y][x],
                        expected,
                        width,
                        height);

--- a/opencl/samples/cpp/check_square.h
+++ b/opencl/samples/cpp/check_square.h
@@ -16,21 +16,20 @@
  * limitations under the License.
  */
 
-bool result_check(TEST_TENSOR_TYPE* const ext_base_in, TEST_TENSOR_TYPE* const ext_base_out, const int width,
+template <typename TestTensor>
+bool result_check(const TestTensor&  ext_base_in, const TestTensor& ext_base_out, const int width,
                   const int height) {
-#define input_buffer ((TEST_TENSOR_TYPE(*)[height][width])ext_base_in)
-#define output_buffer ((TEST_TENSOR_TYPE(*)[height][width])ext_base_out)
     bool result = true;
 
     for (int y = 0; y < height; y++) {
         for (int x = 0; x < width; x++) {
-            TEST_TENSOR_TYPE expected = input_buffer[0][y][x] * input_buffer[0][y][x];
+            TEST_TENSOR_TYPE expected = ext_base_in[y][x] * ext_base_in[y][x];
 
-            if (output_buffer[0][y][x] != expected) {
+            if (ext_base_out[y][x] != expected) {
                 printf("Mismatch at [%d, %d] " TEST_TENSOR_TYPE_SPECIFIER " != " TEST_TENSOR_TYPE_SPECIFIER " Tensor size [%d, %d]\n",
                        x,
                        y,
-                       output_buffer[0][y][x],
+                       ext_base_out[y][x],
                        expected,
                        width,
                        height);

--- a/opencl/samples/cpp/test_all_types.sh
+++ b/opencl/samples/cpp/test_all_types.sh
@@ -34,8 +34,10 @@ for types in char,%c uchar,%c short,%d ushort,%u int,%d uint,%u long,%ld ulong,%
   type_specifier=$2
 
   for compute in cross square copy; do
-    echo Compute $compute with tensor of type $type compute of $compute
-    clang -O0 -g -D TTL_TARGET=c -D TEST_TENSOR_TYPE=$type -D TEST_TENSOR_TYPE_SPECIFIER="\"$type_specifier\"" -D COMPUTE=$compute.h -D CL_TARGET_OPENCL_VERSION=300 -I $TTL_INCLUDE_PATH $TTL_OPEN_CL_INCLUDE_PATH -o TTL_sample_overlap TTL_sample_runner.cpp -lOpenCL -lstdc++
+    external_alignment=$((2 ** ($RANDOM / 4096)))
+    internal_alignment=$((2 ** ($RANDOM / 4096)))
+    echo Compute $compute with tensor of type $type compute of $compute and alignment $external_alignment and $internal_alignment
+    clang -O0 -g -D TTL_TARGET=c -D TEST_TENSOR_TYPE=$type -D TEST_TENSOR_TYPE_SPECIFIER="\"$type_specifier\"" -D COMPUTE=$compute.h -D CL_TARGET_OPENCL_VERSION=300 -D TTL_DEFAULT_EXTERNAL_ALIGNMENT=$external_alignment -D TTL_DEFAULT_INTERNAL_ALIGNMENT=$internal_alignment -I $TTL_INCLUDE_PATH $TTL_OPEN_CL_INCLUDE_PATH -o TTL_sample_overlap TTL_sample_runner.cpp -lOpenCL -lstdc++
     ./TTL_sample_overlap
 
   done

--- a/opencl/samples/python/TTL_double_buffering.cl
+++ b/opencl/samples/python/TTL_double_buffering.cl
@@ -67,8 +67,8 @@ __kernel void TTL_double_buffering(__global TEST_TENSOR_TYPE *restrict ext_base_
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_CONST_EXT_TENSOR_TYPE ext_input_tensor =
         TTL_create_const_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);

--- a/opencl/samples/python/TTL_duplex_buffering.cl
+++ b/opencl/samples/python/TTL_duplex_buffering.cl
@@ -59,8 +59,8 @@ __kernel void TTL_duplex_buffering(__global TEST_TENSOR_TYPE *restrict ext_base_
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_EXT_TENSOR_TYPE ext_input_tensor = TTL_create_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
     const TTL_EXT_TENSOR_TYPE ext_output_tensor = TTL_create_ext_tensor(ext_base_out, tensor_shape_out, ext_layout_out);

--- a/opencl/samples/python/TTL_simplex_buffering.cl
+++ b/opencl/samples/python/TTL_simplex_buffering.cl
@@ -60,8 +60,8 @@ __kernel void TTL_simplex_buffering(__global TEST_TENSOR_TYPE *restrict ext_base
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_EXT_TENSOR_TYPE ext_input_tensor = TTL_create_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
     const TTL_EXT_TENSOR_TYPE ext_output_tensor = TTL_create_ext_tensor(ext_base_out, tensor_shape_out, ext_layout_out);

--- a/opencl/test/test_ttl.cpp
+++ b/opencl/test/test_ttl.cpp
@@ -91,8 +91,8 @@ static const char *ttlDoubleBufferingKernel = R"(
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_const_ext_uchar_tensor_t ext_input_tensor =
         TTL_create_const_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
@@ -162,8 +162,8 @@ static const char *ttlSimplexBufferingKernel = R"(
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_ext_uchar_tensor_t ext_input_tensor = TTL_create_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
     const TTL_ext_uchar_tensor_t ext_output_tensor =
@@ -229,8 +229,8 @@ static const char *ttlDuplexBufferingKernel = R"(
     const TTL_tiler_t output_tiler = TTL_create_tiler(tensor_shape_out, TTL_create_shape(tile_width, tile_height));
 
     // External layouts.
-    const TTL_layout_t ext_layout_in = TTL_create_layout(external_stride_in);
-    const TTL_layout_t ext_layout_out = TTL_create_layout(external_stride_out);
+    const TTL_layout_t ext_layout_in = TTL_create_ext_layout(external_stride_in);
+    const TTL_layout_t ext_layout_out = TTL_create_ext_layout(external_stride_out);
 
     const TTL_ext_uchar_tensor_t ext_input_tensor = TTL_create_ext_tensor(ext_base_in, tensor_shape_in, ext_layout_in);
     const TTL_ext_uchar_tensor_t ext_output_tensor =

--- a/pipelines/TTL_double_scheme.h
+++ b/pipelines/TTL_double_scheme.h
@@ -43,7 +43,7 @@ static inline TTL_INT_SUB_TENSOR_TYPE __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_step_buffering, TTL_IMPORT_DOUBLE_BUFFERING_TYPE *const db, const TTL_tile_t next_tile) {
     // For performance, compute everything possible before waiting for the
     // previous operations to finish.
-    const TTL_layout_t int_layout = TTL_create_layout(next_tile.shape.width, next_tile.shape.height);
+    const TTL_layout_t int_layout = TTL_create_int_layout(next_tile.shape.width, next_tile.shape.height);
     const TTL_INT_SUB_TENSOR_TYPE import_to = TTL_create_int_sub_tensor(
         db->common.int_base[db->common.index], next_tile.shape, int_layout, db->common.ext_tensor_in, next_tile.offset);
     const TTL_CONST_EXT_TENSOR_TYPE import_from = TTL_create_const_ext_tensor(db->common.ext_tensor_in.base,
@@ -60,7 +60,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_IMPORT_DOUBLE_BUFFERING_TYPE *const db, c
 
     db->common.index = (db->common.index + 1) % 2;  // TTL_ARRAYSIZE(db->common.int_base);
 
-    const TTL_layout_t prev_int_layout = TTL_create_layout(db->prev_tile.shape.width, db->prev_tile.shape.height);
+    const TTL_layout_t prev_int_layout = TTL_create_int_layout(db->prev_tile.shape.width, db->prev_tile.shape.height);
     const TTL_INT_SUB_TENSOR_TYPE result = TTL_create_int_sub_tensor(db->common.int_base[db->common.index],
                                                                      db->prev_tile.shape,
                                                                      prev_int_layout,
@@ -83,7 +83,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_IMPORT_DOUBLE_BUFFERING_TYPE *const db, c
  */
 static inline TTL_INT_SUB_TENSOR_TYPE __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_step_buffering, TTL_EXPORT_DOUBLE_BUFFERING_TYPE *const db, TTL_tile_t tile_current) {
-    const TTL_layout_t int_layout = TTL_create_layout(db->prev_tile.shape.width, db->prev_tile.shape.height);
+    const TTL_layout_t int_layout = TTL_create_int_layout(db->prev_tile.shape.width, db->prev_tile.shape.height);
     const TTL_CONST_INT_TENSOR_TYPE export_from = TTL_create_const_int_tensor(
         db->common.int_base[db->common.index], db->prev_tile.shape, int_layout, db->common.ext_tensor_in.elem_size);
     const TTL_EXT_TENSOR_TYPE export_to = TTL_create_ext_tensor(db->common.ext_tensor_in.base,
@@ -100,7 +100,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_EXPORT_DOUBLE_BUFFERING_TYPE *const db, T
                    db->event __TTL_TRACE_LINE);
 
     db->common.index = (db->common.index + 1) % 2;  // TTL_ARRAYSIZE(db->common.int_base);
-    const TTL_layout_t curr_int_layout = TTL_create_layout(tile_current.shape.width, tile_current.shape.height);
+    const TTL_layout_t curr_int_layout = TTL_create_int_layout(tile_current.shape.width, tile_current.shape.height);
     const TTL_INT_SUB_TENSOR_TYPE result = TTL_create_int_sub_tensor(db->common.int_base[db->common.index],
                                                                      tile_current.shape,
                                                                      curr_int_layout,

--- a/pipelines/TTL_duplex_scheme.h
+++ b/pipelines/TTL_duplex_scheme.h
@@ -206,7 +206,7 @@ static inline TTL_IO_TENSOR_TYPE __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *const duplex_buffering, TTL_tile_t tile_current_import,
                TTL_tile_t tile_current_export) {
     const TTL_layout_t next_import_layout =
-        TTL_create_layout(tile_current_import.shape.width, tile_current_import.shape.height);
+        TTL_create_int_layout(tile_current_import.shape.width, tile_current_import.shape.height);
     const TTL_CONST_EXT_TENSOR_TYPE next_import_ext_tensor =
         TTL_create_const_ext_tensor(duplex_buffering->common.ext_tensor_in.base,
                                     tile_current_import.shape,
@@ -234,7 +234,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *const duplex_buffe
                    &(*duplex_buffering->events)[1] __TTL_TRACE_LINE);
 
     const TTL_layout_t int_export_layout =
-        TTL_create_layout(tile_current_export.shape.width, tile_current_export.shape.height);
+        TTL_create_ext_layout(tile_current_export.shape.width, tile_current_export.shape.height);
     const TTL_EXT_TENSOR_TYPE to_export_to = TTL_create_ext_tensor(duplex_buffering->common.ext_tensor_out.base,
                                                                    tile_current_export.shape,
                                                                    duplex_buffering->common.ext_tensor_out.layout,

--- a/pipelines/TTL_simplex_scheme.h
+++ b/pipelines/TTL_simplex_scheme.h
@@ -163,7 +163,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *const simplex_buf
     // For performance, compute everything possible before waiting for the previous operations to finish. The current
     // index contains the tile that is to be exported, so prepare the structures before beginning the export and export.
     const TTL_layout_t next_import_layout =
-        TTL_create_layout(tile_next_import.shape.width, tile_next_import.shape.height);
+        TTL_create_int_layout(tile_next_import.shape.width, tile_next_import.shape.height);
     const TTL_INT_SUB_TENSOR_TYPE next_import_int_sub_tensor =
         TTL_create_int_sub_tensor(simplex_buffer->common.int_base[simplex_buffer->common.index],
                                   tile_next_import.shape,
@@ -177,7 +177,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *const simplex_buf
                                     tile_next_import.offset,
                                     simplex_buffer->common.ext_tensor_in.elem_size);
 
-    const TTL_layout_t int_export_layout = TTL_create_layout(simplex_buffer->next_exported_tile.shape.width,
+    const TTL_layout_t int_export_layout = TTL_create_ext_layout(simplex_buffer->next_exported_tile.shape.width,
                                                              simplex_buffer->next_exported_tile.shape.height);
     const TTL_INT_TENSOR_TYPE int_export_tensor =
         TTL_create_int_tensor(simplex_buffer->common.int_base[simplex_buffer->common.index],
@@ -216,7 +216,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_SIMPLEX_BUFFERING_TYPE *const simplex_buf
     // Can write to out buffer according to size of curr_tile, rather than size
     // recently exported.
     const TTL_layout_t curr_int_layout =
-        TTL_create_layout(tile_current_export.shape.width, tile_current_export.shape.width);
+        TTL_create_int_layout(tile_current_export.shape.width, tile_current_export.shape.width);
     const TTL_INT_SUB_TENSOR_TYPE int_curr_buff_out =
         TTL_create_int_sub_tensor(simplex_buffer->common.int_base[simplex_buffer->common.index],
                                   tile_current_export.shape,


### PR DESCRIPTION
Some platforms require that the Rows/Planes of tensors are aligned to a specific value.

Add two macros TTL_DEFAULT_INTERNAL_ALIGNMENT and
TTL_DEFAULT_EXTERNAL_ALIGNMENT to set these alignement values. The default if undefined is 1 byte.