### PR TITLE
Creation of Preprocessed TTL is not present

### DIFF
--- a/.github/workflows/check-install-preprocessed.yml
+++ b/.github/workflows/check-install-preprocessed.yml
@@ -1,0 +1,23 @@
+name: Check Install
+run-name: ${{ github.actor }} is checking install of preprocessed TTL
+on: [push]
+jobs:
+  Sanity-Check-Install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Info
+        run: |
+          echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+          echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
+          echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Check Install
+        run: |
+          mkdir build
+          cd build
+          cmake -D TTL_PRE_GENERATE=y  -D TTL_COPY_3D=y -D TTL_INSTALL_PATH=$PWD/install-dir ..
+          make install
+
+      - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  # See the License for the specific language governing permissions and
  # limitations under the License.
- 
+
 cmake_minimum_required (VERSION 3.3)
 
 project(TemplateTilingLibrary)
@@ -22,13 +22,17 @@ include(GNUInstallDirs)
 
 if(DEFINED TTL_PRE_GENERATE)
 set(TTL_COMMON_FILES
-    TTL.h
+	TTL.h
+    TTL_macros.h
 )
+
 set(TTL_HEADER_C_FILES
-    ${TTL_COMMON_FILES}
+	TTL_c.h
+	${TTL_COMMON_FILES}
 )
 set(TTL_HEADER_OPENCL_FILES
-    ${TTL_COMMON_FILES}
+	TTL_opencl.h
+	${TTL_COMMON_FILES}
 )
 set(TTL_SOURCE_DIRECTORY
     ${CMAKE_BINARY_DIR}
@@ -135,6 +139,16 @@ macro(InstallTTL type source_directory install_directory ttl_header_files)
         install(FILES ${source_directory}/${file} DESTINATION ${install_directory}/${dir})
     endforeach()
 endmacro()
+
+if(DEFINED TTL_PRE_GENERATE)
+	add_custom_target(PrecompiledHeaders ALL
+		COMMENT "Generating precompiled file before installation"
+		COMMAND ${CMAKE_SOURCE_DIR}/scripts/preprocess.sh -o TTL_opencl.h
+		COMMAND ${CMAKE_SOURCE_DIR}/scripts/preprocess.sh -o TTL_c.h -t c
+		COMMAND cp ${CMAKE_SOURCE_DIR}/scripts/preprocess_ttl.h TTL.h
+		COMMAND cp ${CMAKE_SOURCE_DIR}/TTL_macros.h TTL_macros.h
+	)
+endif()
 
 InstallTTL("c" ${TTL_SOURCE_DIRECTORY} ${TTL_C_INSTALL_PATH} "${TTL_HEADER_C_FILES}")
 InstallTTL("opencl" ${TTL_SOURCE_DIRECTORY} ${TTL_OPENCL_INSTALL_PATH} "${TTL_HEADER_OPENCL_FILES}")

--- a/INSTALL
+++ b/INSTALL
@@ -30,7 +30,7 @@ CMake Options
 -------------
 *TTL_PRE_GENERATE* if defined the TTL library is used to pregenerate a single TTL.h file, this make debug easier.
 *TTL_INSTALL_PATH* changes the default locations all installs, see cmake -LAH for the default locations on a platform.
-*TTL_OPENCL_INSTALL_PATH* if defined overrides TTL_INSTALL_PATH  as the location to place file generate for c
+*TTL_OPENCL_INSTALL_PATH* if defined overrides TTL_INSTALL_PATH  as the location to place file generate for opecl
 *TTL_C_INSTALL_PATH* if defined overrides TTL_INSTALL_PATH as the location to place file generate for c
 *TTL_COPY_3D* if defined pregenerated TTL.h will contain an implementation of async_work_group_copy_3D3D
 *TTL_DEBUG* if defined  TTL.h will contain and output debug information

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ This document outlines the purpose of this sample implementation and provides bu
 
 ## Contents <!-- omit in toc -->
 
-- [Tensor Tiling Library](#tensor-tiling-library)
-  - [Purpose](#purpose)
-  - [Example](#example)
-  - [Doxygen](#doxygen)
-  - [Building And Executing](#building-and-executing)
-    - [CMake](#cmake)
-      - [Tested Supported Systems](#tested-supported-systems)
-      - [Requirements](#requirements)
-      - [Building the Samples](#building-the-samples)
-      - [Installation](#installation)
-  - [Included Unit Tests](#included-unit-tests)
-  - [Bug Reporting](#bug-reporting)
+- [Purpose](#purpose)
+- [Example](#example)
+- [Doxygen](#doxygen)
+- [Building And Executing](#building-and-executing)
+	- [CMake](#cmake)
+		- [Tested Supported Systems](#tested-supported-systems)
+		- [Requirements](#requirements)
+		- [Building the Samples](#building-the-samples)
+		- [Installation](#installation)
+- [Preprocessed Header](#preprocessed-header)
+- [Included Unit Tests](#included-unit-tests)
+- [Bug Reporting](#bug-reporting)
 
 ## Purpose
 
@@ -139,6 +139,21 @@ $ ./TTL_sample_runner.py *.c
 #### Installation
 
 See [INSTALL](./INSTALL).
+
+## Preprocessed Header
+
+TTL it very type strong and uses a lot of macros to create many variants of each method. Whilst powerful this can make debugging tricker. For these reason the ability of preprocess TTL to stdout or the file provided.
+
+```sh
+$ scripts/preprocess.sh [-f TTL_opencl.h] [-t opencl]
+$ scripts/preprocess.sh [-f TTL_c.h] [-t c]
+```
+
+-f defaults to /dev/stdout
+-t defaults to opencl
+
+
+Will output a processed, clang-formatted file to stdout of the given file. Replacing TTL.h with this file, can make life easier.  See also the TTL_PRE_GENERATE option in [INSTALL](./INSTALL).
 
 ## Included Unit Tests
 

--- a/scripts/preprocess.c
+++ b/scripts/preprocess.c
@@ -1,0 +1,6 @@
+#include <stdint.h>
+#include <stdio.h>
+
+TTL_START_MARKER
+
+#include "TTL.h"

--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+
+# git_check.sh
+#
+# Copyright (c) 2023 Mobileye
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Precompile TTL and output to stdout
+
+# Use relative paths below, this requires no symlink an not setup.
+SCRIPTS_DIR=`dirname "$0"`
+WORKING_FILE=`mktemp XXXXXXX.h`
+
+OUTPUT_FILE=/dev/stdout
+TTL_TARGET=opencl
+
+while getopts ":o:t:" opt; do
+  case $opt in
+    o) OUTPUT_FILE="$OPTARG"
+    ;;
+    t) TTL_TARGET="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    exit 1
+    ;;
+  esac
+
+  case $OPTARG in
+    -*) echo "Option $opt needs a valid argument"
+    exit 1
+    ;;
+  esac
+done
+
+clang -DTTL_TARGET=${TTL_TARGET} -DTTL_COPY_3D -I ${SCRIPTS_DIR}/.. -E -CC ${SCRIPTS_DIR}/preprocess.c -o ${WORKING_FILE}
+sed -i '/^# [0-9]*/d' ${WORKING_FILE}
+sed -i -e '1,/TTL_START_MARKER/d' ${WORKING_FILE}
+clang-format -i ${WORKING_FILE}
+
+echo '#pragma once' >${OUTPUT_FILE}
+echo >>${OUTPUT_FILE}
+echo '#include "TTL_macros.h"' >>${OUTPUT_FILE}
+echo >>${OUTPUT_FILE}
+cat ${WORKING_FILE} >>${OUTPUT_FILE}
+
+rm ${WORKING_FILE}

--- a/scripts/preprocess_ttl.h
+++ b/scripts/preprocess_ttl.h
@@ -1,0 +1,88 @@
+/*
+ * TTL.h
+ *
+ * Copyright (c) 2023 Mobileye
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/**
+ * This file is used for the preprocessed file header case.
+ *
+ * It selected TTL_c.h or TTL_opencl.h depending on the value of
+ * TTL_TARGET
+ *
+ * Durring an install with TTL_PRE_GENERATE it will be placed in the
+ * target directory alongside TTL_c.h and TTL_opencl.h
+ */
+
+/**
+ * @def TTL_TARGET
+ *
+ * @brief Define the target for TTL
+ *
+ * TTL can be built for multible targets - native support is
+ *   - opencl - default if TTL_TARGET not predefined.
+ *   - c
+ *
+ * Other platforms can be provided.
+ */
+#ifndef TTL_TARGET
+#define TTL_TARGET opencl
+#endif
+
+/**
+ * @def __TTL_STR_CONCAT1
+ *
+ * Concatenate x and y, must be used within another macro.
+ */
+#define __TTL_STR_CONCAT1(x, y) x##y
+
+/**
+ * @def __TTL_STR_CONCAT2
+ *
+ * Concatenate x and y, can be used standalone
+ */
+#define __TTL_STR_CONCAT2(x, y) __TTL_STR_CONCAT1(x, y)
+
+/**
+ * @def __TTL_STRINGFY1
+ *
+ * Turn s into a "string", must be used within another macro
+ */
+#define __TTL_STRINGFY1(s) #s
+
+/**
+ * @def __TTL_STRINGFY2
+ *
+ * Turn s into a "string", can be used standalone
+ */
+#define __TTL_STRINGFY2(s) __TTL_STRINGFY1(s)
+
+/**
+ * @def TTL_INCLUDE_H
+ *
+ * @brief Create an include name based on TTL_TARGET
+ *
+ * Values in the base distribution include
+ *   - opencl/TTL_types.h
+ *   - c/TTL_types.h
+ */
+// clang-format off
+#define TTL_INCLUDE_H_1 __TTL_STR_CONCAT2(TTL_, TTL_TARGET)
+#define TTL_INCLUDE_H_2 __TTL_STRINGFY2(TTL_INCLUDE_H_1.h)
+// clang-format on
+
+#include TTL_INCLUDE_H_2


### PR DESCRIPTION
Whilst the INSTALL file says that TTL_PRE_GENERATE will cause a preprocessed TTL to be installed, this does not actually work.

1. Make the preprocessed install work.
2. Add a CI hook to make sure it keeps working.

The method used for preprocessed output could be improved using a cmake script.

The preprocessed script is useful when debugging the framework.