### PR TITLE
Improve the Doxygen code to be post processed.

### DIFF
--- a/.github/workflows/check-c-sample.yml
+++ b/.github/workflows/check-c-sample.yml
@@ -1,5 +1,5 @@
 name: Check C Sample
-run-name: ${{ github.actor }} is checking samples
+run-name: ${{ github.actor }} is checking c samples
 on: [push]
 jobs:
   Sanity-Check-C-Sample:

--- a/.github/workflows/check-install-preprocessed.yml
+++ b/.github/workflows/check-install-preprocessed.yml
@@ -1,4 +1,4 @@
-name: Check Install
+name: Check Preprocessed Install
 run-name: ${{ github.actor }} is checking install of preprocessed TTL
 on: [push]
 jobs:

--- a/TTL_create_types.h
+++ b/TTL_create_types.h
@@ -17,7 +17,7 @@
  */
 
 /************************************************************************************************************
- * We genrate sizeof_TYPE to allow for sizeof anything - deals with sizeof(void)
+ * We generate sizeof_TYPE to allow for sizeof anything - deals with sizeof(void)
  ************************************************************************************************************/
 
 #pragma push_macro("TTL_TENSOR_TYPE")
@@ -62,7 +62,7 @@
 #define sizeof_ulong sizeof(ulong)
 #include "TTL_create_type.h"
 
-#endif // TT_TYPES_ONLY_VOID
+#endif  // TT_TYPES_ONLY_VOID
 
 #undef TTL_TYPES_INCLUDE_FILE
 

--- a/TTL_import_export.h
+++ b/TTL_import_export.h
@@ -108,7 +108,7 @@ static inline TTL_shape_t TTL_import_pre_fill(const TTL_int_sub_tensor_t interna
 
     z_offset = 0;  // TTL_MAX(-internal_sub_tensor.origin.sub_offset.z, 0);
     z_cut = 0;     // TTL_MAX((internal_sub_tensor.origin.sub_offset.z + internal_sub_tensor.tensor.shape.depth) -
-                   //     1 /*internal_sub_tensor.origin.shape.depth*/,
+                   //     1 /* Internal_sub_tensor.origin.shape.depth */
                    // 0);
 
     *dst_address = (TTL_local(char *))internal_sub_tensor.tensor.base +

--- a/import_export/TTL_typed_import_export.h
+++ b/import_export/TTL_typed_import_export.h
@@ -24,9 +24,9 @@
  *
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the const external tensor.
- * Complete description of what not how here.
+ * @param event A TTL_event_t type to allow detection of import completion.
  *
- * @return No return value
+ * Complete description of what not how here.
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_import, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
@@ -40,15 +40,16 @@ __TTL_TRACE_FN(TTL_import, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE
  *
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the external tensor.
- * Complete description of what not how here.
+ * @param event A TTL_event_t type to allow detection of import completion.
  *
- * @return No return value
+ * Complete description of what not how here.
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_import, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
                const __TTL_tensor_name(TTL_, , ext_, TTL_TENSOR_TYPE, , _t) external_tensor, TTL_event_t *event) {
-    return TTL_import_base(
-        *TTL_to_void_tensor(&internal_tensor), *TTL_to_void_tensor(TTL_to_const_tensor(&external_tensor)), event __TTL_TRACE_LINE);
+    return TTL_import_base(*TTL_to_void_tensor(&internal_tensor),
+                           *TTL_to_void_tensor(TTL_to_const_tensor(&external_tensor)),
+                           event __TTL_TRACE_LINE);
 }
 
 /**
@@ -56,14 +57,14 @@ __TTL_TRACE_FN(TTL_import, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE
  *
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the external tensor.
- * Complete description of what not how here.
  *
- * @return No return value
+ * Complete description of what not how here.
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_blocking_import, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
                const __TTL_tensor_name(TTL_, const_, ext_, TTL_TENSOR_TYPE, , _t) external_tensor) {
-    TTL_blocking_import_base(*TTL_to_void_tensor(&internal_tensor), *TTL_to_void_tensor(&external_tensor) __TTL_TRACE_LINE);
+    TTL_blocking_import_base(*TTL_to_void_tensor(&internal_tensor),
+                             *TTL_to_void_tensor(&external_tensor) __TTL_TRACE_LINE);
 }
 
 /**
@@ -72,15 +73,15 @@ __TTL_TRACE_FN(TTL_blocking_import, const __TTL_tensor_name(TTL_, , int_, TTL_TE
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the external tensor.
  * Complete description of what not how here.
- *
- * @return No return value
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_blocking_import, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
                const __TTL_tensor_name(TTL_, , ext_, TTL_TENSOR_TYPE, , _t) external_tensor) {
-    const __TTL_tensor_name(TTL_, const_, ext_, TTL_TENSOR_TYPE, , _t) * const cons_external_tensor = TTL_to_const_tensor(&external_tensor);
+    const __TTL_tensor_name(TTL_, const_, ext_, TTL_TENSOR_TYPE, , _t) *const cons_external_tensor =
+        TTL_to_const_tensor(&external_tensor);
 
-    TTL_blocking_import_base(*TTL_to_void_tensor(&internal_tensor), *TTL_to_void_tensor(cons_external_tensor) __TTL_TRACE_LINE);
+    TTL_blocking_import_base(*TTL_to_void_tensor(&internal_tensor),
+                             *TTL_to_void_tensor(cons_external_tensor) __TTL_TRACE_LINE);
 }
 
 /**
@@ -92,13 +93,18 @@ __TTL_TRACE_FN(TTL_blocking_import, const __TTL_tensor_name(TTL_, , int_, TTL_TE
  *
  * @see TTL_import for full API and parameter information
  */
-static inline void __attribute__((overloadable)) __TTL_TRACE_FN(
-    TTL_import_sub_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) internal_sub_tensor,
-    const __TTL_tensor_name(TTL_, const_, ext_, TTL_TENSOR_TYPE, , _t) const_external_tensor, TTL_event_t *event) {
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_import_sub_tensor,
+               const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) internal_sub_tensor,
+               const __TTL_tensor_name(TTL_, const_, ext_, TTL_TENSOR_TYPE, , _t) const_external_tensor,
+               TTL_event_t *event) {
     TTL_local(void *) dst_address;
     TTL_global(void *) src_address;
 
-    const TTL_shape_t import_shape = TTL_import_pre_fill(*TTL_to_void_sub_tensor(&internal_sub_tensor), *TTL_to_void_tensor(&const_external_tensor), &dst_address, &src_address);
+    const TTL_shape_t import_shape = TTL_import_pre_fill(*TTL_to_void_sub_tensor(&internal_sub_tensor),
+                                                         *TTL_to_void_tensor(&const_external_tensor),
+                                                         &dst_address,
+                                                         &src_address);
 
     const TTL_int_tensor_t import_int_tensor = TTL_create_int_tensor(
         dst_address, import_shape, internal_sub_tensor.tensor.layout, internal_sub_tensor.tensor.elem_size);
@@ -114,9 +120,9 @@ static inline void __attribute__((overloadable)) __TTL_TRACE_FN(
  *
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the const external tensor.
- * Complete description of what not how here.
+ * @param event A TTL_event_t type to allow detection of import completion.
  *
- * @return No return value
+ * Complete description of what not how here.
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_export, const __TTL_tensor_name(TTL_, const_, int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
@@ -130,15 +136,16 @@ __TTL_TRACE_FN(TTL_export, const __TTL_tensor_name(TTL_, const_, int_, TTL_TENSO
  *
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the external tensor.
- * Complete description of what not how here.
+ * @param event A TTL_event_t type to allow detection of import completion.
  *
- * @return No return value
+ * Complete description of what not how here.
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_export, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
                const __TTL_tensor_name(TTL_, , ext_, TTL_TENSOR_TYPE, , _t) external_tensor, TTL_event_t *event) {
-    return TTL_export_base(
-        *TTL_to_void_tensor(TTL_to_const_tensor(&internal_tensor)), *TTL_to_void_tensor(&external_tensor), event __TTL_TRACE_LINE);
+    return TTL_export_base(*TTL_to_void_tensor(TTL_to_const_tensor(&internal_tensor)),
+                           *TTL_to_void_tensor(&external_tensor),
+                           event __TTL_TRACE_LINE);
 }
 
 /**
@@ -146,14 +153,14 @@ __TTL_TRACE_FN(TTL_export, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE
  *
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the const external tensor.
- * Complete description of what not how here.
  *
- * @return No return value
+ * Complete description of what not how here.
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_blocking_export, const __TTL_tensor_name(TTL_, const_, int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
                const __TTL_tensor_name(TTL_, , ext_, TTL_TENSOR_TYPE, , _t) external_tensor) {
-    TTL_blocking_export_base(*TTL_to_void_tensor(&internal_tensor), *TTL_to_void_tensor(&external_tensor) __TTL_TRACE_LINE);
+    TTL_blocking_export_base(*TTL_to_void_tensor(&internal_tensor),
+                             *TTL_to_void_tensor(&external_tensor) __TTL_TRACE_LINE);
 }
 
 /**
@@ -161,12 +168,12 @@ __TTL_TRACE_FN(TTL_blocking_export, const __TTL_tensor_name(TTL_, const_, int_, 
  *
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the external tensor.
- * Complete description of what not how here.
  *
- * @return No return value
+ * Complete description of what not how here.
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_blocking_export, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) internal_tensor,
                const __TTL_tensor_name(TTL_, , ext_, TTL_TENSOR_TYPE, , _t) external_tensor) {
-    TTL_blocking_export_base(*TTL_to_void_tensor(TTL_to_const_tensor(&internal_tensor)), *TTL_to_void_tensor(&external_tensor) __TTL_TRACE_LINE);
+    TTL_blocking_export_base(*TTL_to_void_tensor(TTL_to_const_tensor(&internal_tensor)),
+                             *TTL_to_void_tensor(&external_tensor) __TTL_TRACE_LINE);
 }

--- a/opencl/TTL_import_export.h
+++ b/opencl/TTL_import_export.h
@@ -44,8 +44,6 @@ static inline TTL_event_t TTL_get_event() {
  * @def TTL_wait
  *
  * Wait for the array of events passed to enter the complete state.
- *
- * @return No return value
  */
 static inline void __TTL_TRACE_FN(TTL_wait, const int num_events, TTL_event_t *const events) {
 #if __TTL_DEBUG > 0
@@ -63,11 +61,10 @@ static inline void __TTL_TRACE_FN(TTL_wait, const int num_events, TTL_event_t *c
  * @param internal_tensor internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor external_tensor A TTL_int_tensor_t describing the external tensor.
  * @param event event_ptr A pointer to the event which describe the transfer.
- *
- * @return No return value
  */
-static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_import_base, const TTL_int_tensor_t internal_tensor,
-                                  const TTL_const_ext_tensor_t external_tensor, TTL_event_t *event) {
+static inline void __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_import_base, const TTL_int_tensor_t internal_tensor, const TTL_const_ext_tensor_t external_tensor,
+               TTL_event_t *event) {
     *event = async_work_group_copy_3D3D((__local void *)internal_tensor.base,
                                         0,
                                         (__global void *)external_tensor.base,
@@ -83,8 +80,7 @@ static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_import_base,
                                         *event);
 
 #if __TTL_DEBUG > 0
-    __TTL_dump_transaction(
-        false, TTL_to_const_tensor(&internal_tensor), &external_tensor, 0, event __TTL_TRACE_LINE);
+    __TTL_dump_transaction(false, TTL_to_const_tensor(&internal_tensor), &external_tensor, 0, event __TTL_TRACE_LINE);
 #endif  // __TTL_DEBUG
 }
 
@@ -94,10 +90,8 @@ static inline void __attribute__((overloadable)) __TTL_TRACE_FN(TTL_import_base,
  * @param internal_tensor A TTL_int_tensor_t describing the internal tensor.
  * @param external_tensor A TTL_int_tensor_t describing the external tensor.
  * Complete description of what not how here.
- *
- * @return No return value
  */
-static inline void  __TTL_TRACE_FN(TTL_blocking_import_base, const TTL_int_tensor_t internal_tensor,
+static inline void __TTL_TRACE_FN(TTL_blocking_import_base, const TTL_int_tensor_t internal_tensor,
                                   const TTL_const_ext_tensor_t external_tensor) {
     TTL_event_t event = TTL_get_event();
     TTL_import_base(internal_tensor, external_tensor, &event __TTL_TRACE_LINE);
@@ -113,8 +107,6 @@ static inline void  __TTL_TRACE_FN(TTL_blocking_import_base, const TTL_int_tenso
  *
  * @note async_work_group_copy_3D3D if not supported by all OpenCL drivers
  * including some V3.0 drivers. To resolve this define TTL_COPY_3D
- *
- * @return No return value
  */
 static inline void __TTL_TRACE_FN(TTL_export_base, const TTL_const_int_tensor_t internal_tensor,
                                   const TTL_ext_tensor_t external_tensor, TTL_event_t *const event) {
@@ -133,8 +125,7 @@ static inline void __TTL_TRACE_FN(TTL_export_base, const TTL_const_int_tensor_t 
                                         *event);
 
 #if __TTL_DEBUG > 0
-    __TTL_dump_transaction(
-        true, &internal_tensor, TTL_to_const_tensor(&external_tensor), 0, event __TTL_TRACE_LINE);
+    __TTL_dump_transaction(true, &internal_tensor, TTL_to_const_tensor(&external_tensor), 0, event __TTL_TRACE_LINE);
 #endif  // __TTL_DEBUG
 }
 
@@ -145,8 +136,6 @@ static inline void __TTL_TRACE_FN(TTL_export_base, const TTL_const_int_tensor_t 
  * @param external_tensor A TTL_int_sub_tensor_t describing the external tile.
  *
  * Complete description of what not how here.
- *
- * @return No return value
  */
 static inline void __TTL_TRACE_FN(TTL_blocking_export_base, const TTL_const_int_tensor_t internal_tensor,
                                   const TTL_ext_tensor_t external_tensor) {

--- a/opencl/TTL_types.h
+++ b/opencl/TTL_types.h
@@ -52,7 +52,7 @@ typedef int TTL_offset_dim_t;    ///< The type used to hold offsets and origins.
  * printf("Ptr to my struct " TTL_global_printf "\n", ptr_my_struct)
  * @endcode
  */
-#define TTL_global_printf "%p"  ///< Printf specifier for printing global pointers.
+#define TTL_global_printf "%p"
 
 /**
  * @def TTL_local
@@ -72,7 +72,7 @@ typedef int TTL_offset_dim_t;    ///< The type used to hold offsets and origins.
  * TTL_local(unsigned int *)
  * @endcode
  */
-#define TTL_local(type) __local type  ///< Address in the global address space
+#define TTL_local(type) __local type
 
 /**
  * @def TTL_local_printf
@@ -85,7 +85,7 @@ typedef int TTL_offset_dim_t;    ///< The type used to hold offsets and origins.
  * printf("Ptr to my struct " TTL_local_printf "\n", ptr_my_struct)
  * @endcode
  */
-#define TTL_local_printf "%p"  ///< Printf specifier for printing global pointers.
+#define TTL_local_printf "%p"
 
 /**
  * @brief TTL_event_t is a pseudonym for OpenCL event_t

--- a/pipelines/TTL_double_scheme_template.h
+++ b/pipelines/TTL_double_scheme_template.h
@@ -71,7 +71,8 @@
 #undef TTL_DOUBLE_BUFFERING_TYPE
 #define TTL_DOUBLE_BUFFERING_TYPE __TTL_tensor_name(TTL_import_double_, const_, , TTL_TENSOR_TYPE, , _buffering_t)
 #undef TTL_IMPORT_DOUBLE_BUFFERING_TYPE
-#define TTL_IMPORT_DOUBLE_BUFFERING_TYPE __TTL_tensor_name(TTL_import_double_, const_, , TTL_TENSOR_TYPE, , _buffering_t)
+#define TTL_IMPORT_DOUBLE_BUFFERING_TYPE \
+    __TTL_tensor_name(TTL_import_double_, const_, , TTL_TENSOR_TYPE, , _buffering_t)
 #undef TTL_EXT_TENSOR_TYPE
 #define TTL_EXT_TENSOR_TYPE __TTL_tensor_name(TTL_, const_, ext_, TTL_TENSOR_TYPE, , _t)
 #undef TTL_IMPORT_EXPORT_NAME
@@ -82,7 +83,8 @@
 #undef TTL_DOUBLE_BUFFERING_TYPE
 #define TTL_DOUBLE_BUFFERING_TYPE __TTL_tensor_name(TTL_export_double_, const_, , TTL_TENSOR_TYPE, , _buffering_t)
 #undef TTL_EXPORT_DOUBLE_BUFFERING_TYPE
-#define TTL_EXPORT_DOUBLE_BUFFERING_TYPE __TTL_tensor_name(TTL_export_double_, const_, , TTL_TENSOR_TYPE, , _buffering_t)
+#define TTL_EXPORT_DOUBLE_BUFFERING_TYPE \
+    __TTL_tensor_name(TTL_export_double_, const_, , TTL_TENSOR_TYPE, , _buffering_t)
 #undef TTL_EXT_TENSOR_TYPE
 #define TTL_EXT_TENSOR_TYPE __TTL_tensor_name(TTL_, , ext_, TTL_TENSOR_TYPE, , _t)
 #undef TTL_IMPORT_EXPORT_NAME
@@ -98,11 +100,9 @@
  */
 typedef struct {
     TTL_common_buffering_t(TTL_TENSOR_TYPE *, TTL_EXT_TENSOR_TYPE, TTL_EXT_TENSOR_TYPE,
-                           2) common;  ///< @brief The information that is common to all pipeline schemes
-
-    TTL_event_t *event;
-
-    TTL_tile_t prev_tile; /** @brief Store of the previous imported/exported tile */
+                           2) common;  ///< The information that is common to all pipeline schemes
+    TTL_event_t *event;                ///< A pointer to the event that is used to track the progress of the transfer
+    TTL_tile_t prev_tile;              ///< Store of the previous imported/exported tile */
 } TTL_DOUBLE_BUFFERING_TYPE;
 
 #ifdef TTL_IMPORT_DOUBLE
@@ -111,7 +111,7 @@ typedef struct {
  *
  * @param int_base1 A pointer to the 1st local buffer
  * @param int_base2 A pointer to the 2nd local buffer
- * @param ext_tensor_in A tensor describing the input in global memory
+ * @param ext_tensor A tensor describing the input in global memory
  * @param event A pointer to the event to use for the inward (external to
  * internal) transfer completion
  * @param first_tile The first tile to fetch for the scheme
@@ -138,10 +138,9 @@ typedef struct {
  *
  * @enduml
  */
-static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable)) TTL_start_import_double_buffering(TTL_local(TTL_TENSOR_TYPE *) int_base1,
-                                                                          TTL_local(TTL_TENSOR_TYPE *) int_base2,
-                                                                          TTL_EXT_TENSOR_TYPE ext_tensor,
-                                                                          TTL_event_t *event, TTL_tile_t first_tile);
+static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable))
+TTL_start_import_double_buffering(TTL_local(TTL_TENSOR_TYPE *) int_base1, TTL_local(TTL_TENSOR_TYPE *) int_base2,
+                                  TTL_EXT_TENSOR_TYPE ext_tensor, TTL_event_t *event, TTL_tile_t first_tile);
 #endif
 
 #ifdef TTL_EXPORT_DOUBLE
@@ -150,7 +149,7 @@ static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable)) TTL_start_
  *
  * @param int_base1 A pointer to the 1st local buffer
  * @param int_base2 A pointer to the 2nd local buffer
- * @param ext_tensor_out  A tensor describing the output in global memory
+ * @param ext_tensor  A tensor describing the output in global memory
  * @param event A pointer to the event to use for the inward and outward
  * transfer completion
  *
@@ -178,22 +177,20 @@ static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable)) TTL_start_
  *
  * @enduml
  */
-static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable)) __TTL_TRACE_FN(TTL_start_export_double_buffering, TTL_local(TTL_TENSOR_TYPE *) int_base1,
-                                                                          TTL_local(TTL_TENSOR_TYPE *) int_base2,
-                                                                          TTL_EXT_TENSOR_TYPE ext_tensor,
-                                                                          TTL_event_t *event);
+static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_start_export_double_buffering, TTL_local(TTL_TENSOR_TYPE *) int_base1,
+               TTL_local(TTL_TENSOR_TYPE *) int_base2, TTL_EXT_TENSOR_TYPE ext_tensor, TTL_event_t *event);
 #endif
 
 static inline TTL_INT_SUB_TENSOR_TYPE __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_step_buffering, TTL_DOUBLE_BUFFERING_TYPE *const db, const TTL_tile_t next_tile);
 
-static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable)) __TTL_TRACE_FN(TTL_IMPORT_EXPORT_NAME(TTL_start, double_buffering),
-                                                       TTL_local(TTL_TENSOR_TYPE *) int_base1,
-                                                       TTL_local(TTL_TENSOR_TYPE *) int_base2, TTL_EXT_TENSOR_TYPE ext_tensor,
-                                                       TTL_event_t *event
+static inline TTL_DOUBLE_BUFFERING_TYPE __attribute__((overloadable))
+__TTL_TRACE_FN(TTL_IMPORT_EXPORT_NAME(TTL_start, double_buffering), TTL_local(TTL_TENSOR_TYPE *) int_base1,
+               TTL_local(TTL_TENSOR_TYPE *) int_base2, TTL_EXT_TENSOR_TYPE ext_tensor, TTL_event_t *event
 #ifdef TTL_IMPORT_DOUBLE
-                                                       ,
-                                                       TTL_tile_t first_tile
+               ,
+               TTL_tile_t first_tile
 #endif
 ) {
     TTL_DOUBLE_BUFFERING_TYPE result;

--- a/pipelines/TTL_duplex_scheme.h
+++ b/pipelines/TTL_duplex_scheme.h
@@ -163,11 +163,10 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *const duplex_buffe
  * start
  *
  * :Create a TTL_tiler_t with TTL_create_tiler;
- * :Create a TTL_duplex_buffering_t Structure with 2 Buffers
- * 1 input buffer, 1 output buffer;
+ * :Create a TTL_duplex_buffering_t Structure with 2 Buffers 1 input buffer, 1 output buffer;
  * :NumberOfTiles = TTL_number_of_tiles(tiler);
  *
- * for each tile:
+ * while (for each tile)
  *
  *   :Call TTL_step_buffering for the current tile
  *
@@ -221,8 +220,7 @@ __TTL_TRACE_FN(TTL_step_buffering, TTL_DUPLEX_BUFFERING_TYPE *const duplex_buffe
                                   *TTL_to_const_tensor(&duplex_buffering->common.ext_tensor_in),
                                   tile_current_import.offset);
 
-    const TTL_CONST_INT_TENSOR_TYPE  next_export_int_tensor =
-        duplex_buffering->prev_out_tensors.to_export_from;
+    const TTL_CONST_INT_TENSOR_TYPE next_export_int_tensor = duplex_buffering->prev_out_tensors.to_export_from;
     const TTL_EXT_TENSOR_TYPE next_export_ext_tensor = duplex_buffering->prev_out_tensors.to_export_to;
 
     if (TTL_tile_empty(tile_current_import) == false)

--- a/pipelines/TTL_schemes_common.h
+++ b/pipelines/TTL_schemes_common.h
@@ -44,13 +44,13 @@
  */
 #define TTL_common_buffering_t(ext_base_type, ext_tensor_in_type, ext_tensor_out_type, int_bases)                 \
     struct {                                                                                                      \
-        int index; /** @brief Describes the current buffer index when pipelining. For single 0->1->0, for double  \
+        int index; /*!< Describes the current buffer index when pipelining. For single 0->1->0, for double  \
                       0->1->0->1... etc */                                                                        \
         TTL_local(                                                                                                \
-            ext_base_type) int_base[int_bases]; /** @brief The internal base addresses of the pipelined tiles. */ \
+            ext_base_type) int_base[int_bases]; /*!< The internal base addresses of the pipelined tiles. */ \
                                                                                                                   \
-        ext_tensor_in_type ext_tensor_in;   /** @brief  The external tensor being input*/                         \
-        ext_tensor_out_type ext_tensor_out; /** @brief  The external tensor being output*/                        \
+        ext_tensor_in_type ext_tensor_in;   /*!< The external tensor being input */                         \
+        ext_tensor_out_type ext_tensor_out; /*!< The external tensor being output */                        \
     }
 
 #undef TTL_INT_SUB_TENSOR_TYPE

--- a/scripts/doxyfile.in
+++ b/scripts/doxyfile.in
@@ -68,7 +68,7 @@ OUTPUT_DIRECTORY       = gh-pages
 # performance problems for the file system.
 # The default value is: NO.
 
-CREATE_SUBDIRS         = 
+CREATE_SUBDIRS         =
 
 # If the ALLOW_UNICODE_NAMES tag is set to YES, doxygen will allow non-ASCII
 # characters to appear in the names of generated files. If set to NO, non-ASCII
@@ -239,12 +239,6 @@ TAB_SIZE               = 4
 # newlines.
 
 ALIASES                =
-
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
@@ -703,7 +697,7 @@ FILE_VERSION_FILTER    =
 # DoxygenLayout.xml, doxygen will parse it automatically even if the LAYOUT_FILE
 # tag is left empty.
 
-LAYOUT_FILE            =  
+LAYOUT_FILE            =
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files containing
 # the reference definitions. This must be a list of .bib files. The .bib
@@ -821,6 +815,7 @@ FILE_PATTERNS          = *.c \
                          *.h \
                          *.d \
                          *.dox \
+                         *.md \
                          *.py
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
@@ -1066,13 +1061,6 @@ CLANG_OPTIONS          =
 # The default value is: YES.
 
 ALPHABETICAL_INDEX     = YES
-
-# The COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns in
-# which the alphabetical index list will be split.
-# Minimum value: 1, maximum value: 20, default value: 5.
-# This tag requires that the tag ALPHABETICAL_INDEX is set to YES.
-
-COLS_IN_ALPHA_INDEX    = 5
 
 # In case all classes in a project start with a common prefix, all classes will
 # be put under the same header in the alphabetical index. The IGNORE_PREFIX tag

--- a/scripts/preprocess.c
+++ b/scripts/preprocess.c
@@ -3,4 +3,4 @@
 
 TTL_START_MARKER
 
-#include "TTL.h"
+#include "../TTL.h"

--- a/scripts/preprocess.sh
+++ b/scripts/preprocess.sh
@@ -19,17 +19,20 @@
 # Precompile TTL and output to stdout
 
 # Use relative paths below, this requires no symlink an not setup.
-SCRIPTS_DIR=`dirname "$0"`
-WORKING_FILE=`mktemp XXXXXXX.h`
+SCRIPTS_DIR=$(dirname "$0")
+WORKSPACE="${WORKSPACE:-$(realpath $SCRIPTS_DIR/..)}"
 
 OUTPUT_FILE=/dev/stdout
 TTL_TARGET=opencl
+REMOVE_LINE_NUMBERS="y"
 
-while getopts ":o:t:" opt; do
+while getopts ":o:t:r" opt; do
   case $opt in
-    o) OUTPUT_FILE="$OPTARG"
+    o) OUTPUT_FILE="$PWD"/"$OPTARG"
     ;;
     t) TTL_TARGET="$OPTARG"
+    ;;
+    r) REMOVE_LINE_NUMBERS="n"
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     exit 1
@@ -43,9 +46,40 @@ while getopts ":o:t:" opt; do
   esac
 done
 
-clang -DTTL_TARGET=${TTL_TARGET} -DTTL_COPY_3D -I ${SCRIPTS_DIR}/.. -E -CC ${SCRIPTS_DIR}/preprocess.c -o ${WORKING_FILE}
-sed -i '/^# [0-9]*/d' ${WORKING_FILE}
+pushd ${WORKSPACE}
+
+WORKING_FILE=`mktemp XXXXXXX.h`
+
+clang -DTTL_TARGET=${TTL_TARGET} -DTTL_COPY_3D -E -CC scripts/preprocess.c -o ${WORKING_FILE}
+
+if [[ "${REMOVE_LINE_NUMBERS}" == "y" ]]; then
+	sed -i '/^# [0-9]*/d' ${WORKING_FILE}
+else
+	sed -i 's/scripts\/..\///g' ${WORKING_FILE}
+fi
+
 sed -i -e '1,/TTL_START_MARKER/d' ${WORKING_FILE}
+
+##################
+# Below is a bit of a work in progress to try and sed our way to code that produces
+# the best output when clang-format runs
+##################
+
+# Clang format to get an evenish starting point
+clang-format -i ${WORKING_FILE}
+
+# We end up with trailing \ because of the macros, these mean nothing post processing so replace them.
+sed -i 's/\\$//g' ${WORKING_FILE}
+
+# When an end comment marker is not the end of the line then add a new line
+sed -i 's/\*\/[^%]/\*\/\n/g' ${WORKING_FILE}
+
+# Add some blank lines before comments, clang-format then evens it all up.
+# We look for three types /*\n /**\n because we want to avoid /**<
+sed -i 's/\/\*[\n ]/\n\n\n\n\/\*/g' ${WORKING_FILE}
+sed -i 's/\/\*\*[\n ]/\n\n\n\n\/\*/g' ${WORKING_FILE}
+
+# Now get clang to make it pretty!
 clang-format -i ${WORKING_FILE}
 
 echo '#pragma once' >${OUTPUT_FILE}
@@ -55,3 +89,5 @@ echo >>${OUTPUT_FILE}
 cat ${WORKING_FILE} >>${OUTPUT_FILE}
 
 rm ${WORKING_FILE}
+
+popd

--- a/scripts/split_doxgen.py
+++ b/scripts/split_doxgen.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# To update the generated files From the src directory run this command.
+# in the src directory
+#
+# find . -name *.h -exec python ../scripts/generate_enum_strings.py {} \;
+#
+# The script generate_enum_strings.sh will do this for you.
+
+import sys
+import os
+import re
+
+def ProcessFile(input_filename):
+    output_file_names = set()
+    output_file_stream = None
+
+    with open(input_filename, "r") as input_file_stream:
+        for line in input_file_stream.readlines():
+            regex = re.search("# [0-9]* \"([A-Za-z_0-9-\./]*h)\"", line)
+            if regex:
+                if output_file_stream:
+                    output_file_stream.close()
+                    output_file_stream = None
+
+                output_file_name = os.path.relpath(os.path.abspath(regex.group(1)))
+                print(output_file_name)
+
+                if output_file_name in output_file_names:
+                    output_file_stream = open(output_file_name, "r+")
+                else:
+                    output_path = os.path.dirname(output_file_name)
+
+                    if (output_path != "") and (not os.path.exists(output_path)):
+                        os.makedirs(output_path)
+                    output_file_stream = open(output_file_name, "w+")
+                    output_file_names.add(output_file_name)
+
+                output_file_stream.seek(0, 2)
+            else:
+                if output_file_stream is not None:
+                    output_file_stream.write(line)
+
+    output_file_stream.close()
+    output_file_stream = None
+
+    for output_file_name in output_file_names:
+        os.system("clang-format -i " + output_file_name)
+
+if __name__ == "__main__":
+    ProcessFile(sys.argv[1])

--- a/tensors/TTL_tensor_rw.h
+++ b/tensors/TTL_tensor_rw.h
@@ -52,7 +52,7 @@ __TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR
 /**
  * @brief  Read a value from a tensor
  *
- * @param tensor A TTL_int_[type]_sub_tensor_t describing the internal tensor.
+ * @param sub_tensor A TTL_int_[type]_sub_tensor_t describing the internal tensor.
  * @param x The offset in the x dimension
  * @param y The offset in the y dimension
  * @param z The offset in the z dimension
@@ -87,8 +87,6 @@ __TTL_TRACE_FN(TTL_read_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR
  * @param x The offset in the x dimension
  * @param y The offset in the y dimension
  * @param z The offset in the z dimension
- *
- * @return No return value
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, , _t) tensor,
@@ -111,13 +109,11 @@ __TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSO
 /**
  * @brief  Write a value from a tensor
  *
- * @param tensor A TTL_int_[type]_tensor_t describing the internal tensor.
+ * @param sub_tensor A TTL_int_[type]_tensor_t describing the internal tensor.
  * @param value The value to right
  * @param x The offset in the x dimension
  * @param y The offset in the y dimension
  * @param z The offset in the z dimension
- *
- * @return No return value
  */
 static inline void __attribute__((overloadable))
 __TTL_TRACE_FN(TTL_write_tensor, const __TTL_tensor_name(TTL_, , int_, TTL_TENSOR_TYPE, sub_, _t) sub_tensor,

--- a/tensors/TTL_tensors_common.h
+++ b/tensors/TTL_tensors_common.h
@@ -134,12 +134,12 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
  * @param type The type of the tensor - should be any valid c type
  * @param const_2 The const type to create - should be empty or const
  */
-#define __TTL_typedef_tensor_t(TTL_scope, const_1, location, type, const_2)                                     \
-    typedef struct {                                                                                            \
-        TTL_scope(const_2 type *) base; /** @brief The base address of the tensor in the local address space */ \
-        TTL_dim_t elem_size;            /** @brief The sizeof the elements in the tensor */                     \
-        TTL_layout_t layout;            /** @brief The layout of the tensor, @see TTL_layout_t */               \
-        TTL_shape_t shape;              /** @brief The shape of the tensor in 3 dimensions */                   \
+#define __TTL_typedef_tensor_t(TTL_scope, const_1, location, type, const_2)                               \
+    typedef struct {                                                                                      \
+        TTL_scope(const_2 type *) base; /*!< The base address of the tensor in the local address space */ \
+        TTL_dim_t elem_size;            /*!< The sizeof the elements in the tensor */                     \
+        TTL_layout_t layout;            /*!< The layout of the tensor, @see TTL_layout_t */               \
+        TTL_shape_t shape;              /*!< The shape of the tensor in 3 dimensions */                   \
     } __TTL_tensor_name(TTL_, const_1, location, type, , _t)
 
 /**
@@ -166,11 +166,11 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
         /* union {                                                                                           \
     TTL_ext_tensor_t(base_ptr_type) tensor;                                                                  \
     TTL_ext_tensor_base_t;                                                                                   \
-    //};*/                                                                                                   \
+    //}; */                                                                                                  \
         __TTL_tensor_name(TTL_, const_1, location, type, , _t) tensor;                                       \
         struct {                                                                                             \
-            TTL_shape_t shape;       /** @brief The shape of the origin tensor in 3 dimensions */            \
-            TTL_offset_t sub_offset; /** @brief The offset of the sub tensor from the origin sensor */       \
+            TTL_shape_t shape;       /*!< The shape of the origin tensor in 3 dimensions */                  \
+            TTL_offset_t sub_offset; /*!< The offset of the sub tensor from the origin sensor */             \
         } origin;                                                                                            \
     } __TTL_tensor_name(TTL_, const_1, location, type, sub_, _t)
 
@@ -292,7 +292,7 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
      * As above but a dummy parameter is used to select the version to all                                        \
      */                                                                                                           \
     static inline __TTL_tensor_name(TTL_, const_1, location, type, , _t) __attribute__((overloadable))            \
-        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, , )(TTL_scope(type *) unused) {                            \
+        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, , )(TTL_scope(type *) unused) {           \
         (void)unused;                                                                                             \
         return __TTL_tensor_name(TTL_create_empty_, const_1, location, type, , )();                               \
     }
@@ -403,20 +403,19 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
         return result;                                                                                                \
     }                                                                                                                 \
                                                                                                                       \
-    /**                                                                                                                \
-     * @brief Create an empty location sub tensor. Empty means it has all dimensions set                                   \
-     * to zero                                                                                                         \
-     *                                                                                                                 \
-     * @param unused Simply defined to allow selection of the functon to call.                                         \
-     *                                                                                                                 \
-     * As above but a dummy parameter is used to select the version to all                                             \
-     */                                                                                                                \
-    static inline __TTL_tensor_name(TTL_, const_1, location, type, sub_, _t) __attribute__((overloadable))                 \
-        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, sub_, )(TTL_scope(type *) unused) {                                 \
-        (void)unused;                                                                                                  \
-        return __TTL_tensor_name(TTL_create_empty_, const_1, location, type, sub_, )();                                    \
+    /**                                                                                                               \
+     * @brief Create an empty location sub tensor. Empty means it has all dimensions set                              \
+     * to zero                                                                                                        \
+     *                                                                                                                \
+     * @param unused Simply defined to allow selection of the functon to call.                                        \
+     *                                                                                                                \
+     * As above but a dummy parameter is used to select the version to all                                            \
+     */                                                                                                               \
+    static inline __TTL_tensor_name(TTL_, const_1, location, type, sub_, _t) __attribute__((overloadable))            \
+        __TTL_tensor_no_type_name(TTL_create_empty_, const_1, location, sub_, )(TTL_scope(type *) unused) {           \
+        (void)unused;                                                                                                 \
+        return __TTL_tensor_name(TTL_create_empty_, const_1, location, type, sub_, )();                               \
     }
-
 
 /************************************************************************************************************
  * Create the create tensor functions for different overloads
@@ -450,6 +449,7 @@ static inline TTL_offset_dim_t TTL_linearize(const TTL_offset_t offset, const TT
      * @brief __TTL_tensor_overloaded_name(TTL_create_, const_1, location, type, sub, )                        \
      *                                                                                                         \
      * @param base A pointer to a global address                                                               \
+     * @param shape Description of the shape of the tensor that base points                                    \
      * @param layout The layout of the ## location ## tensor                                                   \
      *                                                                                                         \
      * @details                                                                                                \


### PR DESCRIPTION
Although Doxygen tries to deal with Macro expansion, the level of expansion in TTL defeats it.

How TTL can produce a post-processed file - and by reprocessing this file to produce the original files and then running doxygen on these files, we can produce better Doxygen dealing with all of the types generated.

The process is.
 1. Produce the single post-processor file.
 2. Split this file into the files indicated by the preprocessor # n "filename.h" n tags.

Run Doxygen on these regenerated files.