### PR TITLE
Use regenerated Doxygen method for deploying to gh_pages

### DIFF
--- a/.github/actions/build_doxygen/Dockerfile
+++ b/.github/actions/build_doxygen/Dockerfile
@@ -1,0 +1,8 @@
+# Container image that runs your code
+FROM alpine:edge
+
+# Copies your code file from your action repository to the filesystem path `/` of the container
+COPY entrypoint.sh /entrypoint.sh
+
+# Code file to execute when the docker container starts up (`entrypoint.sh`)
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/build_doxygen/action.yml
+++ b/.github/actions/build_doxygen/action.yml
@@ -1,0 +1,15 @@
+name: 'Generate Doxygen Action'
+description: 'Generate Documentation Using Doxygen Script'
+branding:
+  icon: 'book-open'
+  color: 'gray-dark'
+inputs:
+  working-directory:
+    description: 'Working directory'
+    required: true
+    default: '.'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.working-directory }}

--- a/.github/actions/build_doxygen/entrypoint.sh
+++ b/.github/actions/build_doxygen/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -x
+set -e
+
+# $1 is the directory where doxygen script should be executed
+if [ ! -d $1 ]; then
+  echo "Path $1 could not be found!"
+  exit 1
+fi
+
+cd $1
+
+# Add the packages required by scripts/generate_doxygen.sh
+apk add bash doxygen graphviz ttf-freefont coreutils clang clang-extra-tools rsync python3
+
+# execute doxygen
+bash scripts/generate_doxygen.sh

--- a/.github/workflows/build-and-deploy-doxygen.yml
+++ b/.github/workflows/build-and-deploy-doxygen.yml
@@ -15,10 +15,9 @@ jobs:
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "💡 Building Doxygen."
       - name: Build Doxygen
-        uses: mattnotmitt/doxygen-action@v1.9.4
+        uses: ./.github/actions/build_doxygen
         with:
             working-directory: .
-            doxyfile-path: scripts/doxyfile.in
 
       - if: github.ref == 'refs/heads/main'
         name: Deploy Doxygen

--- a/opencl/TTL_async_work_group_copy_3D3D.h
+++ b/opencl/TTL_async_work_group_copy_3D3D.h
@@ -22,7 +22,7 @@
 */
 
 /**
- * @brief async_work_group_copy_3D3D if not supported by all OpenCL drivers
+ * @brief async_work_group_copy_3D3D is not supported by all OpenCL drivers
  *
  * This is an implementation that can be included by defining TTL_COPY_3D
  */
@@ -47,7 +47,7 @@ __attribute__((overloadable)) event_t async_work_group_copy_3D3D(
 }
 
 /**
- * @brief async_work_group_copy_3D3D if not supported by all OpenCL drivers
+ * @brief async_work_group_copy_3D3D is not supported by all OpenCL drivers
  *
  * This is an implementation that can be included by defining TTL_COPY_3D
  */

--- a/opencl/TTL_import_export.h
+++ b/opencl/TTL_import_export.h
@@ -22,7 +22,7 @@
 
 #ifdef TTL_COPY_3D
 /*
- * async_work_group_copy_3D3D if not supported by all OpenCL drivers
+ * async_work_group_copy_3D3D is not supported by all OpenCL drivers
  * including some V3.0 drivers. To resolve this define TTL_COPY_3D
  */
 #include "TTL_async_work_group_copy_3D3D.h"
@@ -105,7 +105,7 @@ static inline void __TTL_TRACE_FN(TTL_blocking_import_base, const TTL_int_tensor
  * @param external_tensor external_tensor A TTL_int_sub_tensor_t describing the external tile.
  * @param event event_ptr A pointer to the event which describe the transfer.
  *
- * @note async_work_group_copy_3D3D if not supported by all OpenCL drivers
+ * @note async_work_group_copy_3D3D is not supported by all OpenCL drivers
  * including some V3.0 drivers. To resolve this define TTL_COPY_3D
  */
 static inline void __TTL_TRACE_FN(TTL_export_base, const TTL_const_int_tensor_t internal_tensor,

--- a/scripts/generate_doxygen.sh
+++ b/scripts/generate_doxygen.sh
@@ -33,7 +33,6 @@ rm -rf gh-pages/html
 rm -rf gh-pages/xml
 rm -rf gh-pages/*.pu
 
-
 RECREATION_DIRECTORY=`mktemp -d XXXXXXX_TTL`
 cd ${RECREATION_DIRECTORY}
 


### PR DESCRIPTION
The patch that improved the Doxygen code to be post-processed code worked, but the deployment to gh_pages did not use it.

Update deploy Doxygen script to run the generate_doxygen.sh script.